### PR TITLE
feat: Stop citizen wandering during player conversations

### DIFF
--- a/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
+++ b/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
@@ -167,6 +167,15 @@ public class ServerEventHandler {
                 checkConversationDistance(player);
             }
 
+            AbstractEntityCitizen talkingCitizen = ConversationManager.getActiveEntityForPlayer(player.getUUID());
+            if (talkingCitizen != null
+                    && !McTalkingConfig.INSTANCE.instance().continueWorkDuringConversation) {
+                talkingCitizen.getLookControl().setLookAt(player, 30f, 30f);
+                if (!talkingCitizen.getNavigation().isDone()) {
+                    talkingCitizen.getNavigation().stop();
+                }
+            }
+
             if (ConversationManager.isPlayerInConversation(playerId))
                 continue;
 

--- a/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
+++ b/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
@@ -67,6 +67,12 @@ public class McTalkingConfig {
     @SerialEntry(comment = "If true, text messages from mumbling and citizen-to-citizen conversations will also be sent to nearby players in chat.")
     public boolean sendMumblingAndConversationsToChat = false;
 
+    @AutoGen(category = "general", group = "interaction")
+    @TickBox
+    @SerialEntry(comment = "If true, citizens continue wandering normally while in a player conversation. "
+            + "If false (default), they stay in place for the duration of the conversation.")
+    public boolean continueWorkDuringConversation = false;
+
     // Citizen - Citizen Interaction (Conversations between them)
     @AutoGen(category = "citizens", group = "citizen_to_citizen")
     @TickBox

--- a/src/main/java/me/sshcrack/mc_talking/mixin/EntityAICitizenWanderMixin.java
+++ b/src/main/java/me/sshcrack/mc_talking/mixin/EntityAICitizenWanderMixin.java
@@ -1,0 +1,28 @@
+package me.sshcrack.mc_talking.mixin;
+
+import com.minecolonies.core.entity.ai.minimal.EntityAICitizenWander;
+import com.minecolonies.core.entity.citizen.EntityCitizen;
+import me.sshcrack.mc_talking.ConversationManager;
+import me.sshcrack.mc_talking.config.McTalkingConfig;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = EntityAICitizenWander.class, remap = false)
+public class EntityAICitizenWanderMixin {
+
+    @Shadow
+    @Final
+    protected EntityCitizen citizen;
+
+    @Inject(method = "canUse", at = @At("HEAD"), cancellable = true)
+    private void mc_talking$suppressWanderingDuringConversation(CallbackInfoReturnable<Boolean> cir) {
+        if (McTalkingConfig.INSTANCE.instance().continueWorkDuringConversation) return;
+        if (ConversationManager.getPlayerForEntity(citizen.getUUID()) != null) {
+            cir.setReturnValue(false);
+        }
+    }
+}

--- a/src/main/resources/assets/mc_talking/lang/en_us.json
+++ b/src/main/resources/assets/mc_talking/lang/en_us.json
@@ -73,6 +73,8 @@
   "yacl3.config.mc_talking:config.language.desc": "Preferred response language. If players ask to speak in another language, the AI will for their session.",
   "yacl3.config.mc_talking:config.respondInGroups": "Respond in Groups",
   "yacl3.config.mc_talking:config.respondInGroups.desc": "If disabled, citizens ignore your microphone while you are in a voice chat group.",
+  "yacl3.config.mc_talking:config.continueWorkDuringConversation": "Continue Wandering During Conversation",
+  "yacl3.config.mc_talking:config.continueWorkDuringConversation.desc": "When enabled, citizens will continue wandering normally while talking to a player. When disabled (default), they stand still for the duration of the conversation.",
   "yacl3.config.mc_talking:config.sendMumblingAndConversationsToChat": "Send Mumbling to Chat",
   "yacl3.config.mc_talking:config.sendMumblingAndConversationsToChat.desc": "If enabled, text messages from mumbling and citizen-to-citizen conversations will also be sent to nearby players in chat.",
   "yacl3.config.mc_talking:config.maxConcurrentAgents": "Max Concurrent Agents",

--- a/src/main/resources/mc_talking.mixins.json
+++ b/src/main/resources/mc_talking.mixins.json
@@ -9,7 +9,7 @@
     "AbstractEntityCitizenMixin",
     "CitizenDataAccessor",
     "CitizenDataMixin",
-
+    "EntityAICitizenWanderMixin",
     "RaidManagerMixin",
     "ServerEntityMixin",
     "SoundUtilsMixin"


### PR DESCRIPTION
## Summary

When a player starts a conversation with a citizen, the citizen previously continued wandering via `EntityAICitizenWander`. This PR suppresses wander AI during player conversations and adds a quality-of-life look-at refresh to keep the citizen facing the player.

## Changes

### New Mixin — `EntityAICitizenWanderMixin`
- **Path:** `src/main/java/me/sshcrack/mc_talking/mixin/EntityAICitizenWanderMixin.java`
- Injects at `HEAD` of `canUse()` and returns `false` when `ConversationManager.getPlayerForEntity()` returns a non-null player (citizen is in a conversation)
- Config-gated via `continueWorkDuringConversation` (default `false` = wandering suppressed)

### Config
- New `@TickBox` field `continueWorkDuringConversation` in the `general/interaction` config group
- When `true`, citizens wander normally during conversations (opt-out); when `false` (default), they stay in place
- English translations added

### ServerEventHandler
- Per-tick look-at refresh via `getLookControl().setLookAt(player, 30f, 30f)` while the citizen is in a player conversation
- Navigation stop is also re-applied each tick to prevent wander AI re-activation

## Why This Approach

- **Mixin on `canUse()`** is the minimal surface: returning `false` from the `IDLE → decide()` transition causes the AI to skip navigation entirely
- No new duck interfaces needed — `ConversationManager.getPlayerForEntity(UUID)` already answers the predicate
- Config is opt-out: default behavior suppresses wandering (new desired behavior)

## Testing

- [x] Conversation starts → citizen stops wandering
- [x] Conversation ends normally → citizen resumes wandering
- [x] Citizen is a guard → no effect (original `canUse()` already returns false for guards)
- [x] `continueWorkDuringConversation = true` → original behavior restored