### PR TITLE
feat: add debug commands and restructure under /talking_colonists

### DIFF
--- a/src/main/java/me/sshcrack/mc_talking/ConversationManager.java
+++ b/src/main/java/me/sshcrack/mc_talking/ConversationManager.java
@@ -15,6 +15,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -210,6 +211,38 @@ public class ConversationManager {
         GeminiWsClient client = clients.remove(entityId);
         if (client != null) client.close();
         McTalking.LOGGER.info("[ConversationManager] Evicted slot for entity {} to make room", entityId);
+    }
+
+    // -------------------------------------------------------------------------
+    // Debug / inspection accessors
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns an unmodifiable view of all active AI clients (citizen UUID → client).
+     */
+    public static Map<UUID, GeminiWsClient> getClients() {
+        return Collections.unmodifiableMap(clients);
+    }
+
+    /**
+     * Returns an unmodifiable view of the citizen→player reverse mapping.
+     */
+    public static Map<UUID, UUID> getCitizenToPlayer() {
+        return Collections.unmodifiableMap(citizenToPlayer);
+    }
+
+    /**
+     * Returns an unmodifiable view of the player→citizen mapping.
+     */
+    public static Map<UUID, UUID> getPlayerConversationPartners() {
+        return Collections.unmodifiableMap(playerConversationPartners);
+    }
+
+    /**
+     * Returns an unmodifiable view of the last session end times.
+     */
+    public static Map<UUID, Long> getLastSessionEndTimes() {
+        return Collections.unmodifiableMap(lastSessionEndTime);
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
+++ b/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
@@ -1,7 +1,7 @@
 package me.sshcrack.mc_talking;
 
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
-import me.sshcrack.mc_talking.commands.ListToolsCommand;
+import me.sshcrack.mc_talking.commands.McTalkingDebugCommand;
 import me.sshcrack.mc_talking.conversations.CitizenConversation;
 import me.sshcrack.mc_talking.item.CitizenTalkingDevice;
 import me.sshcrack.mc_talking.network.AiStatus;
@@ -76,7 +76,7 @@ public class ServerEventHandler {
 
     @SubscribeEvent
     public void onRegisterCommands(RegisterCommandsEvent event) {
-        ListToolsCommand.register(event.getDispatcher());
+        McTalkingDebugCommand.register(event.getDispatcher());
     }
 
     /**

--- a/src/main/java/me/sshcrack/mc_talking/commands/DebugCitizenCommand.java
+++ b/src/main/java/me/sshcrack/mc_talking/commands/DebugCitizenCommand.java
@@ -1,0 +1,136 @@
+package me.sshcrack.mc_talking.commands;
+
+import com.minecolonies.api.colony.ICitizenData;
+import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import me.sshcrack.mc_talking.ConversationManager;
+import me.sshcrack.mc_talking.config.PersonalityArchetype;
+import me.sshcrack.mc_talking.duck.AbstractEntityCitizenAiStatusProvider;
+import me.sshcrack.mc_talking.duck.CitizenDataMemoryExtended;
+import me.sshcrack.mc_talking.duck.CitizenDataPersonalityExtended;
+import me.sshcrack.mc_talking.manager.GeminiWsClient;
+import me.sshcrack.mc_talking.network.AiStatus;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.network.chat.Component;
+
+import java.util.UUID;
+
+public class DebugCitizenCommand {
+
+    private static final SimpleCommandExceptionType NOT_A_CITIZEN =
+            new SimpleCommandExceptionType(Component.translatable("mc_talking.debug.not_citizen"));
+
+    private DebugCitizenCommand() {
+    }
+
+    public static void addTo(LiteralArgumentBuilder<CommandSourceStack> root) {
+        root.then(Commands.literal("citizen")
+                .then(Commands.argument("target", EntityArgument.entity())
+                        .executes(ctx -> execute(ctx.getSource(), EntityArgument.getEntity(ctx, "target")))));
+    }
+
+    private static int execute(CommandSourceStack source, net.minecraft.world.entity.Entity target) throws CommandSyntaxException {
+        if (!(target instanceof AbstractEntityCitizen citizen)) {
+            throw NOT_A_CITIZEN.create();
+        }
+
+        ICitizenData data = citizen.getCitizenData();
+        if (data == null) {
+            source.sendFailure(Component.translatable("mc_talking.debug.no_citizen_data"));
+            return 0;
+        }
+
+        UUID citizenId = citizen.getUUID();
+        AiStatus aiStatus = ((AbstractEntityCitizenAiStatusProvider) citizen).mc_talking$getAiStatus();
+        boolean isBusy = ConversationManager.isCitizenBusy(citizen);
+        boolean onCooldown = ConversationManager.isCitizenOnCooldown(citizen);
+        UUID playerPartner = ConversationManager.getPlayerForEntity(citizenId);
+        GeminiWsClient client = ConversationManager.getClientForEntity(citizenId);
+
+        var personalityExt = (CitizenDataPersonalityExtended) data;
+        PersonalityArchetype archetype = personalityExt.mc_talking$getPersonality();
+        String customPersonality = personalityExt.mc_talking$getCustomPersonality();
+
+        String jobName = data.getJob() != null
+                ? Component.translatable(data.getJob().getJobRegistryEntry().getTranslationKey()).getString()
+                : "unemployed";
+        String colonyName = data.getColony() != null ? data.getColony().getName() : "none";
+        int colonyId = data.getColony() != null ? data.getColony().getID() : -1;
+
+        String partnerName = null;
+        if (playerPartner != null) {
+            var player = source.getServer().getPlayerList().getPlayer(playerPartner);
+            if (player != null) partnerName = player.getName().getString();
+        }
+
+        String cooldownStr = "none";
+        Long lastEnd = ConversationManager.getLastSessionEndTimes().get(citizenId);
+        if (lastEnd != null) {
+            cooldownStr = McTalkingDebugCommand.cooldownRemaining(lastEnd,
+                    me.sshcrack.mc_talking.config.McTalkingConfig.INSTANCE.instance().citizenCooldownSeconds);
+        }
+
+        String personalityStr;
+        if (archetype != null) personalityStr = archetype.name();
+        else if (customPersonality != null) personalityStr = "custom: " + customPersonality.substring(0, Math.min(40, customPersonality.length())) + "…";
+        else personalityStr = "none";
+
+        String sessionType;
+        if (client == null) sessionType = "none";
+        else if (client instanceof me.sshcrack.mc_talking.manager.CitizenWsClient cws && cws.isMumbling()) sessionType = "mumble";
+        else sessionType = "player";
+
+        String sessionDuration = client != null ? McTalkingDebugCommand.formatDuration(client.getSessionStartTimeMs()) : "—";
+
+        var doubleOpt = data.getEntity();
+        Double healthPct = doubleOpt.isPresent()
+                ? (doubleOpt.get().getHealth() / Math.max(1.0f, doubleOpt.get().getMaxHealth())) * 100.0
+                : null;
+
+        final String fPartnerName = partnerName;
+        final String fSessionType = sessionType;
+        final String fSessionDuration = sessionDuration;
+        final String fCooldownStr = cooldownStr;
+        final String fPersonalityStr = personalityStr;
+        final Double fHealthPct = healthPct;
+
+        source.sendSuccess(() -> {
+            var msg = Component.literal("")
+                    .append(Component.translatable("mc_talking.debug.citizen_header", data.getName())
+                            .withStyle(ChatFormatting.GOLD, ChatFormatting.BOLD))
+                    .append(Component.literal("\n"))
+                    .append(field("UUID", citizenId.toString()))
+                    .append(field("Colony", colonyName + " (#" + colonyId + ")"))
+                    .append(field("Job", jobName))
+                    .append(field("Health", fHealthPct != null ? String.format("%.1f%%", fHealthPct) : "not loaded"))
+                    .append(field("Saturation", String.format("%.1f", data.getSaturation())))
+                    .append(field("AI Status", aiStatus.name()))
+                    .append(field("Personality", fPersonalityStr))
+                    .append(field("Active Session", fSessionType))
+                    .append(field("Duration", fSessionDuration));
+
+            if (fPartnerName != null) {
+                msg.append(field("Talking to", fPartnerName));
+            }
+            msg.append(field("Cooldown", fCooldownStr));
+            msg.append(field("isChild", String.valueOf(data.isChild())));
+            msg.append(field("isSick", String.valueOf(data.getCitizenDiseaseHandler().isSick())));
+            msg.append(field("isHomeless", String.valueOf(data.getHomeBuilding() == null)));
+
+            return msg;
+        }, false);
+        return 1;
+    }
+
+    private static Component field(String label, String value) {
+        return Component.literal("")
+                .append(Component.literal("  §7" + label + ": §f").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal(value).withStyle(ChatFormatting.WHITE))
+                .append(Component.literal("\n"));
+    }
+}

--- a/src/main/java/me/sshcrack/mc_talking/commands/DebugConnectionsCommand.java
+++ b/src/main/java/me/sshcrack/mc_talking/commands/DebugConnectionsCommand.java
@@ -1,0 +1,89 @@
+package me.sshcrack.mc_talking.commands;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
+import me.sshcrack.mc_talking.ConversationManager;
+import me.sshcrack.mc_talking.duck.AbstractEntityCitizenAiStatusProvider;
+import me.sshcrack.mc_talking.manager.CitizenWsClient;
+import me.sshcrack.mc_talking.manager.GeminiWsClient;
+import me.sshcrack.mc_talking.network.AiStatus;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class DebugConnectionsCommand {
+
+    private DebugConnectionsCommand() {
+    }
+
+    public static void addTo(LiteralArgumentBuilder<CommandSourceStack> root) {
+        root.then(Commands.literal("connections")
+                .executes(ctx -> execute(ctx.getSource())));
+    }
+
+    private static int execute(CommandSourceStack source) {
+        Map<UUID, GeminiWsClient> clients = ConversationManager.getClients();
+        Map<UUID, UUID> citizenToPlayer = ConversationManager.getCitizenToPlayer();
+
+        if (clients.isEmpty()) {
+            source.sendSuccess(() -> Component.translatable("mc_talking.debug.no_connections")
+                    .withStyle(ChatFormatting.YELLOW), false);
+            return 1;
+        }
+
+        source.sendSuccess(() -> {
+            var msg = Component.literal("")
+                    .append(Component.translatable("mc_talking.debug.connections_header", clients.size())
+                            .withStyle(ChatFormatting.GOLD, ChatFormatting.BOLD));
+
+            for (var entry : clients.entrySet()) {
+                UUID citizenId = entry.getKey();
+                GeminiWsClient client = entry.getValue();
+                AbstractEntityCitizen entity = client.getEntity();
+                String citizenName = entity.getCitizenData() != null
+                        ? entity.getCitizenData().getName()
+                        : citizenId.toString().substring(0, 8) + "…";
+
+                String playerName = null;
+                UUID playerId = citizenToPlayer.get(citizenId);
+                if (playerId != null) {
+                    var player = source.getServer().getPlayerList().getPlayer(playerId);
+                    if (player != null) playerName = player.getName().getString();
+                }
+
+                AiStatus status = ((AbstractEntityCitizenAiStatusProvider) entity).mc_talking$getAiStatus();
+                String sessionType = (client instanceof CitizenWsClient cws && cws.isMumbling())
+                        ? "mumble"
+                        : "player";
+
+                String duration = McTalkingDebugCommand.formatDuration(client.getSessionStartTimeMs());
+
+                msg.append(Component.literal("\n  §7- "))
+                        .append(Component.literal(citizenName).withStyle(ChatFormatting.AQUA))
+                        .append(Component.literal(" [").withStyle(ChatFormatting.GRAY))
+                        .append(Component.literal(status.name()).withStyle(
+                                status == AiStatus.TALKING ? ChatFormatting.GREEN :
+                                        status == AiStatus.ERROR || status == AiStatus.QUOTA_EXCEEDED ? ChatFormatting.RED :
+                                                status == AiStatus.THINKING ? ChatFormatting.YELLOW :
+                                                        ChatFormatting.GRAY))
+                        .append(Component.literal(" - ").withStyle(ChatFormatting.GRAY))
+                        .append(Component.literal(sessionType).withStyle(ChatFormatting.WHITE))
+                        .append(Component.literal("] ").withStyle(ChatFormatting.GRAY))
+                        .append(Component.literal(duration).withStyle(ChatFormatting.DARK_GRAY));
+
+                if (playerName != null) {
+                    msg.append(Component.literal(" §8(player: "))
+                            .append(Component.literal(playerName).withStyle(ChatFormatting.GRAY))
+                            .append(Component.literal(")").withStyle(ChatFormatting.DARK_GRAY));
+                }
+            }
+
+            return msg;
+        }, false);
+        return 1;
+    }
+}

--- a/src/main/java/me/sshcrack/mc_talking/commands/DebugEventsCommand.java
+++ b/src/main/java/me/sshcrack/mc_talking/commands/DebugEventsCommand.java
@@ -1,0 +1,106 @@
+package me.sshcrack.mc_talking.commands;
+
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.IColonyManager;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import me.sshcrack.mc_talking.util.ColonyEventBuffer;
+import net.minecraft.ChatFormatting;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.List;
+
+public class DebugEventsCommand {
+
+    private DebugEventsCommand() {
+    }
+
+    public static void addTo(LiteralArgumentBuilder<CommandSourceStack> root) {
+        root.then(Commands.literal("events")
+                .executes(ctx -> execute(ctx.getSource(), -1))
+                .then(Commands.argument("colony_id", IntegerArgumentType.integer())
+                        .executes(ctx -> execute(ctx.getSource(), IntegerArgumentType.getInteger(ctx, "colony_id")))));
+    }
+
+    private static int execute(CommandSourceStack source, int colonyId) {
+        if (colonyId < 0) {
+            ServerPlayer player = source.getPlayer();
+            if (player == null) {
+                source.sendFailure(Component.translatable("mc_talking.debug.no_colony_specified"));
+                return 0;
+            }
+            IColony colony = IColonyManager.getInstance().getIColonyByOwner(player.serverLevel(), player.getUUID());
+            if (colony == null) {
+                colony = IColonyManager.getInstance().getColonyByPosFromWorld(player.level(), player.blockPosition());
+            }
+            if (colony == null) {
+                source.sendFailure(Component.translatable("mc_talking.debug.no_colony_found"));
+                return 0;
+            }
+            colonyId = colony.getID();
+        }
+
+        final int fColonyId = colonyId;
+
+        IColony colony = IColonyManager.getInstance().getColonyByWorld(colonyId, source.getLevel());
+        String colonyName = colony != null ? colony.getName() : "unknown";
+        int eventWindow = me.sshcrack.mc_talking.config.McTalkingConfig.INSTANCE.instance().colonyEventWindowSeconds;
+        List<ColonyEventBuffer.ColonyEvent> recentEvents = ColonyEventBuffer.getRecentEvents(fColonyId, eventWindow > 0 ? eventWindow : 300);
+
+        long millisSinceRaid = ColonyEventBuffer.millisSinceRaid(fColonyId);
+        int lostCitizens = ColonyEventBuffer.getLostCitizens(fColonyId);
+
+        source.sendSuccess(() -> {
+            var msg = Component.literal("")
+                    .append(Component.translatable("mc_talking.debug.events_header", colonyName, fColonyId)
+                            .withStyle(ChatFormatting.GOLD, ChatFormatting.BOLD))
+                    .append(Component.literal("\n"));
+
+            // Raid info
+            if (millisSinceRaid < Long.MAX_VALUE) {
+                long secondsSinceRaid = millisSinceRaid / 1000;
+                String raidStr;
+                if (secondsSinceRaid < 60) raidStr = secondsSinceRaid + "s ago";
+                else if (secondsSinceRaid < 3600) raidStr = (secondsSinceRaid / 60) + "m " + (secondsSinceRaid % 60) + "s ago";
+                else raidStr = (secondsSinceRaid / 3600) + "h ago";
+                msg.append(Component.literal("  §7Last raid: §f")
+                        .append(Component.literal(raidStr).withStyle(ChatFormatting.RED))
+                        .append(Component.literal(" §7(" + lostCitizens + " citizens lost)\n")));
+            } else {
+                msg.append(Component.literal("  §7Last raid: §8none\n"));
+            }
+
+            if (me.sshcrack.mc_talking.config.McTalkingConfig.INSTANCE.instance().raidTraumaDurationSeconds > 0) {
+                boolean inTrauma = ColonyEventBuffer.isInTrauma(fColonyId,
+                        me.sshcrack.mc_talking.config.McTalkingConfig.INSTANCE.instance().raidTraumaDurationSeconds);
+                msg.append(Component.literal("  §7Raid trauma: ")
+                        .append(Component.literal(inTrauma ? "§cACTIVE" : "§ainactive"))
+                        .append(Component.literal("\n")));
+            }
+
+            // Recent events
+            msg.append(Component.literal("  §7Recent events (" + recentEvents.size() + "):\n"));
+            if (recentEvents.isEmpty()) {
+                msg.append(Component.literal("    §8(none)"));
+            } else {
+                for (int i = 0; i < recentEvents.size(); i++) {
+                    ColonyEventBuffer.ColonyEvent evt = recentEvents.get(i);
+                    long ageSec = (System.currentTimeMillis() - evt.timestampMs()) / 1000;
+                    String ageStr = ageSec < 60 ? ageSec + "s" : (ageSec / 60) + "m " + (ageSec % 60) + "s";
+                    msg.append(Component.literal("    §f" + (i + 1) + ". §7[" + evt.type().name() + "] ")
+                            .append(Component.literal(evt.description()).withStyle(ChatFormatting.WHITE))
+                            .append(Component.literal(" §8(" + ageStr + " ago)"))
+                            .append(Component.literal("\n")));
+                }
+            }
+
+            return msg;
+        }, false);
+        return 1;
+    }
+}

--- a/src/main/java/me/sshcrack/mc_talking/commands/DebugMemoryCommand.java
+++ b/src/main/java/me/sshcrack/mc_talking/commands/DebugMemoryCommand.java
@@ -1,0 +1,119 @@
+package me.sshcrack.mc_talking.commands;
+
+import com.minecolonies.api.colony.ICitizenData;
+import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import me.sshcrack.mc_talking.ConversationManager;
+import me.sshcrack.mc_talking.config.McTalkingConfig;
+import me.sshcrack.mc_talking.conversations.memory.data.CitizenMemories;
+import me.sshcrack.mc_talking.conversations.memory.data.CitizenRelationshipMemory;
+import me.sshcrack.mc_talking.duck.CitizenDataMemoryExtended;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.network.chat.Component;
+
+public class DebugMemoryCommand {
+    private static final SimpleCommandExceptionType NOT_A_CITIZEN =
+            new SimpleCommandExceptionType(Component.translatable("mc_talking.debug.not_citizen"));
+
+    private DebugMemoryCommand() {
+    }
+
+    public static void addTo(LiteralArgumentBuilder<CommandSourceStack> root) {
+        root.then(Commands.literal("memory")
+                .then(Commands.argument("target", EntityArgument.entity())
+                        .executes(ctx -> execute(ctx.getSource(), EntityArgument.getEntity(ctx, "target")))));
+    }
+
+    private static int execute(CommandSourceStack source, net.minecraft.world.entity.Entity target) throws CommandSyntaxException {
+        if (!(target instanceof AbstractEntityCitizen citizen)) {
+            throw NOT_A_CITIZEN.create();
+        }
+
+        ICitizenData data = citizen.getCitizenData();
+        if (data == null) {
+            source.sendFailure(Component.translatable("mc_talking.debug.no_citizen_data"));
+            return 0;
+        }
+
+        boolean memoryEnabled = McTalkingConfig.INSTANCE.instance().enableCitizenMemory;
+        if (!memoryEnabled) {
+            source.sendSuccess(() -> Component.translatable("mc_talking.debug.memory_disabled")
+                    .withStyle(ChatFormatting.YELLOW), false);
+            return 1;
+        }
+
+        CitizenMemories mem = ((CitizenDataMemoryExtended) data).mc_talking$getMemory();
+        if (mem == null) {
+            source.sendSuccess(() -> Component.translatable("mc_talking.debug.memory_empty")
+                    .withStyle(ChatFormatting.YELLOW), false);
+            return 1;
+        }
+
+        String sessionToken = mem.getSessionToken();
+        boolean hasSessionToken = sessionToken != null && !sessionToken.isBlank();
+        var facts = mem.getFacts();
+        var events = mem.getEvents();
+        var relationships = mem.getRelationships();
+
+        source.sendSuccess(() -> {
+            var msg = Component.literal("")
+                    .append(Component.translatable("mc_talking.debug.memory_header", data.getName())
+                            .withStyle(ChatFormatting.GOLD, ChatFormatting.BOLD))
+                    .append(Component.literal("\n"))
+                    .append(Component.literal("  §7Session Token: §f")
+                            .append(Component.literal(hasSessionToken ? "§a§lSET" : "§8none"))
+                            .append(Component.literal("\n")));
+
+            // Facts
+            msg.append(Component.literal("  §7Facts (" + facts.size() + "):\n"));
+            if (facts.isEmpty()) {
+                msg.append(Component.literal("    §8(none)\n"));
+            } else {
+                int i = 1;
+                for (String fact : facts) {
+                    msg.append(Component.literal("    §f" + i + ". ")
+                            .append(Component.literal(fact).withStyle(ChatFormatting.WHITE))
+                            .append(Component.literal("\n")));
+                    i++;
+                }
+            }
+
+            // Events
+            msg.append(Component.literal("  §7Events (" + events.size() + "):\n"));
+            if (events.isEmpty()) {
+                msg.append(Component.literal("    §8(none)\n"));
+            } else {
+                int i = 1;
+                for (String event : events) {
+                    msg.append(Component.literal("    §f" + i + ". ")
+                            .append(Component.literal(event).withStyle(ChatFormatting.WHITE))
+                            .append(Component.literal("\n")));
+                    i++;
+                }
+            }
+
+            // Relationships
+            msg.append(Component.literal("  §7Relationships (" + relationships.size() + "):\n"));
+            if (relationships.isEmpty()) {
+                msg.append(Component.literal("    §8(none)"));
+            } else {
+                for (int i = 0; i < relationships.size(); i++) {
+                    CitizenRelationshipMemory rel = relationships.get(i);
+                    String targetStr = rel.getTargetUUID().toString().substring(0, 8) + "…";
+                    msg.append(Component.literal("    §f" + (i + 1) + ". §7" + targetStr
+                                    + " §8| §f" + rel.getType().name()
+                                    + " §8| §ffactor=" + String.format("%.2f", rel.getFactor()))
+                            .append(Component.literal("\n")));
+                }
+            }
+
+            return msg;
+        }, false);
+        return 1;
+    }
+}

--- a/src/main/java/me/sshcrack/mc_talking/commands/DebugStatusCommand.java
+++ b/src/main/java/me/sshcrack/mc_talking/commands/DebugStatusCommand.java
@@ -1,0 +1,87 @@
+package me.sshcrack.mc_talking.commands;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import me.sshcrack.mc_talking.ConversationManager;
+import me.sshcrack.mc_talking.config.McTalkingConfig;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+
+public class DebugStatusCommand {
+
+    private DebugStatusCommand() {
+    }
+
+    public static void addTo(LiteralArgumentBuilder<CommandSourceStack> root) {
+        root.then(Commands.literal("status")
+                .executes(ctx -> execute(ctx.getSource())));
+    }
+
+    private static int execute(CommandSourceStack source) {
+        var config = McTalkingConfig.INSTANCE.instance();
+        var clients = ConversationManager.getClients();
+        var citizenToPlayer = ConversationManager.getCitizenToPlayer();
+        var lastSessionEndTimes = ConversationManager.getLastSessionEndTimes();
+
+        int activeSessions = clients.size();
+        int playerSessions = citizenToPlayer.size();
+        int nonPlayerSessions = activeSessions - playerSessions;
+        int maxAgents = config.maxConcurrentAgents;
+        boolean hasKey = !config.geminiApiKey.isEmpty();
+
+        source.sendSuccess(() -> {
+            var msg = Component.literal("")
+                    .append(Component.translatable("mc_talking.debug.status_header")
+                            .withStyle(ChatFormatting.GOLD, ChatFormatting.BOLD))
+                    .append(Component.literal("\n"));
+
+            // API key
+            msg.append(Component.literal("  "))
+                    .append(Component.translatable("mc_talking.debug.api_key_status",
+                            McTalkingDebugCommand.booleanToStr(hasKey)))
+                    .withStyle(hasKey ? ChatFormatting.GREEN : ChatFormatting.RED)
+                    .append(Component.literal("\n"));
+
+            // Sessions
+            msg.append(Component.literal("  "))
+                    .append(Component.translatable("mc_talking.debug.status_sessions",
+                            activeSessions, maxAgents, playerSessions, nonPlayerSessions))
+                    .withStyle(ChatFormatting.WHITE)
+                    .append(Component.literal("\n"));
+
+            // Cooldown
+            String cooldownStr = config.citizenCooldownSeconds > 0
+                    ? config.citizenCooldownSeconds + "s"
+                    : "disabled";
+            msg.append(Component.literal("  "))
+                    .append(Component.translatable("mc_talking.debug.status_cooldown", cooldownStr))
+                    .withStyle(ChatFormatting.GRAY)
+                    .append(Component.literal("\n"));
+
+            // Toggles
+            msg.append(Component.literal("  "))
+                    .append(Component.translatable("mc_talking.debug.status_memory",
+                            McTalkingDebugCommand.booleanToStr(config.enableCitizenMemory)))
+                    .withStyle(ChatFormatting.GRAY)
+                    .append(Component.literal("\n"));
+            msg.append(Component.literal("  "))
+                    .append(Component.translatable("mc_talking.debug.status_personality",
+                            McTalkingDebugCommand.booleanToStr(config.enablePersonalityArchetypes)))
+                    .withStyle(ChatFormatting.GRAY)
+                    .append(Component.literal("\n"));
+            msg.append(Component.literal("  "))
+                    .append(Component.translatable("mc_talking.debug.status_citizen_to_citizen",
+                            McTalkingDebugCommand.booleanToStr(config.enableCitizenToCitizenConversation)))
+                    .withStyle(ChatFormatting.GRAY)
+                    .append(Component.literal("\n"));
+            msg.append(Component.literal("  "))
+                    .append(Component.translatable("mc_talking.debug.status_pregeneration",
+                            McTalkingDebugCommand.booleanToStr(config.enablePregeneration)))
+                    .withStyle(ChatFormatting.GRAY);
+
+            return msg;
+        }, false);
+        return 1;
+    }
+}

--- a/src/main/java/me/sshcrack/mc_talking/commands/ListToolsCommand.java
+++ b/src/main/java/me/sshcrack/mc_talking/commands/ListToolsCommand.java
@@ -2,7 +2,7 @@ package me.sshcrack.mc_talking.commands;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonParser;
-import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
@@ -55,17 +55,15 @@ public class ListToolsCommand {
         return 0;
     }
 
-    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+    public static void addTo(LiteralArgumentBuilder<CommandSourceStack> root) {
         var builder = Commands.literal("list_tools");
 
         for (String fn_name : AITools.getRegisteredFunctionNames()) {
-            builder
-                    .then(Commands.literal(fn_name)
-                            .executes(context -> get_description(context, fn_name)));
+            builder.then(Commands.literal(fn_name)
+                    .executes(context -> get_description(context, fn_name)));
         }
 
-        dispatcher.register(builder
-                .requires(source -> source.hasPermission(2))
+        root.then(builder
                 .executes(ctx -> {
                     var src = ctx.getSource();
                     var tools = AITools.getRegisteredFunctionNames();

--- a/src/main/java/me/sshcrack/mc_talking/commands/McTalkingDebugCommand.java
+++ b/src/main/java/me/sshcrack/mc_talking/commands/McTalkingDebugCommand.java
@@ -1,0 +1,89 @@
+package me.sshcrack.mc_talking.commands;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+import me.sshcrack.mc_talking.ConversationManager;
+import me.sshcrack.mc_talking.config.McTalkingConfig;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+
+public class McTalkingDebugCommand {
+
+    private McTalkingDebugCommand() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        var root = Commands.literal("talking_colonists")
+                .requires(source -> source.hasPermission(2))
+                .executes(McTalkingDebugCommand::overview);
+
+        DebugStatusCommand.addTo(root);
+        DebugConnectionsCommand.addTo(root);
+        DebugCitizenCommand.addTo(root);
+        DebugMemoryCommand.addTo(root);
+        DebugEventsCommand.addTo(root);
+        ListToolsCommand.addTo(root);
+
+        dispatcher.register(root);
+    }
+
+    private static int overview(CommandContext<CommandSourceStack> ctx) {
+        var source = ctx.getSource();
+        var config = McTalkingConfig.INSTANCE.instance();
+        boolean hasKey = !config.geminiApiKey.isEmpty();
+        int activeSessions = ConversationManager.getClients().size();
+        int playerSessions = ConversationManager.getCitizenToPlayer().size();
+        int maxAgents = config.maxConcurrentAgents;
+
+        source.sendSuccess(() -> Component.literal("")
+                .append(Component.translatable("mc_talking.debug.header")
+                        .withStyle(ChatFormatting.GOLD))
+                .append(Component.literal("\n"))
+                .append(Component.translatable(hasKey ? "mc_talking.debug.api_key_set" : "mc_talking.debug.api_key_empty")
+                        .withStyle(hasKey ? ChatFormatting.GREEN : ChatFormatting.RED))
+                .append(Component.literal("\n"))
+                .append(Component.translatable("mc_talking.debug.active_sessions",
+                                activeSessions, maxAgents, playerSessions)
+                        .withStyle(ChatFormatting.WHITE))
+                .append(Component.literal("\n"))
+                .append(Component.translatable("mc_talking.debug.config_toggles",
+                                booleanToStr(config.enableCitizenMemory),
+                                booleanToStr(config.enablePersonalityArchetypes),
+                                booleanToStr(config.enableCitizenToCitizenConversation),
+                                booleanToStr(config.enablePregeneration))
+                        .withStyle(ChatFormatting.GRAY))
+                .append(Component.literal("\n"))
+                .append(Component.translatable("mc_talking.debug.cooldown",
+                                config.citizenCooldownSeconds > 0
+                                        ? String.valueOf(config.citizenCooldownSeconds)
+                                        : "disabled")
+                        .withStyle(ChatFormatting.GRAY)),
+                false);
+        return 1;
+    }
+
+    static String booleanToStr(boolean value) {
+        return value ? "§a✔" : "§c✘";
+    }
+
+    static String formatDuration(long startTimeMs) {
+        long elapsed = (System.currentTimeMillis() - startTimeMs) / 1000;
+        if (elapsed < 60) return elapsed + "s";
+        long mins = elapsed / 60;
+        long secs = elapsed % 60;
+        return mins + "m " + secs + "s";
+    }
+
+    static String cooldownRemaining(long lastEndTime, int cooldownSeconds) {
+        if (cooldownSeconds <= 0) return "none";
+        long elapsed = (System.currentTimeMillis() - lastEndTime) / 1000;
+        long remaining = cooldownSeconds - elapsed;
+        if (remaining <= 0) return "ready";
+        if (remaining < 60) return remaining + "s";
+        long mins = remaining / 60;
+        long secs = remaining % 60;
+        return mins + "m " + secs + "s";
+    }
+}

--- a/src/main/java/me/sshcrack/mc_talking/conversations/memory/data/CitizenMemories.java
+++ b/src/main/java/me/sshcrack/mc_talking/conversations/memory/data/CitizenMemories.java
@@ -34,6 +34,10 @@ public class CitizenMemories {
         return events;
     }
 
+    public List<CitizenRelationshipMemory> getRelationships() {
+        return relationships;
+    }
+
     public void addFact(String fact) {
         facts.add(fact);
     }

--- a/src/main/java/me/sshcrack/mc_talking/manager/GeminiWsClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/GeminiWsClient.java
@@ -95,6 +95,12 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
     private final List<String> pendingTextAfterTalking = Collections.synchronizedList(new ArrayList<>());
     private final List<Runnable> onCloseActions = Collections.synchronizedList(new ArrayList<>());
 
+    private final long sessionStartTimeMs = System.currentTimeMillis();
+
+    public long getSessionStartTimeMs() {
+        return sessionStartTimeMs;
+    }
+
     @Nullable
     private VisibleCitizenStatus lastStatus;
 

--- a/src/main/resources/assets/mc_talking/lang/en_us.json
+++ b/src/main/resources/assets/mc_talking/lang/en_us.json
@@ -54,6 +54,38 @@
   "mc_talking.commands.tool_description": "The description of tool %s is:\n%s\nProperties:%s",
   "mc_talking.commands.list_tools": "List of available tools:\n%s",
 
+  "mc_talking.debug.not_citizen": "Target must be a MineColonies citizen.",
+  "mc_talking.debug.no_citizen_data": "Citizen has no data (offline/unloaded).",
+  "mc_talking.debug.no_connections": "No active Gemini connections.",
+  "mc_talking.debug.no_colony_specified": "Specify a colony ID or execute near a colony.",
+  "mc_talking.debug.no_colony_found": "Could not find a colony for you. Specify a colony ID.",
+  "mc_talking.debug.memory_disabled": "Citizen memory is disabled in config.",
+  "mc_talking.debug.memory_empty": "No memories stored for this citizen.",
+
+  "mc_talking.debug.header": "--- McTalking Debug Overview ---",
+  "mc_talking.debug.api_key_set": "  API Key: §a✔ §r(set)",
+  "mc_talking.debug.api_key_empty": "  API Key: §c✘ §r(not set)",
+  "mc_talking.debug.active_sessions": "  Active sessions: %d/%d (%d player)",
+  "mc_talking.debug.config_toggles": "  Memory: %s  Personality: %s  C2C: %s  Pregen: %s",
+  "mc_talking.debug.cooldown": "  Cooldown: %s",
+
+  "mc_talking.debug.status_header": "--- McTalking Status ---",
+  "mc_talking.debug.api_key_status": "API Key: %s",
+  "mc_talking.debug.status_sessions": "Sessions: %d/%d (%d player, %d non-player)",
+  "mc_talking.debug.status_cooldown": "Cooldown: %s",
+  "mc_talking.debug.status_memory": "Memory: %s",
+  "mc_talking.debug.status_personality": "Personality: %s",
+  "mc_talking.debug.status_citizen_to_citizen": "Citizen-to-Citizen: %s",
+  "mc_talking.debug.status_pregeneration": "Pregeneration: %s",
+
+  "mc_talking.debug.connections_header": "--- Active Connections (%d) ---",
+
+  "mc_talking.debug.citizen_header": "--- Citizen Info: %s ---",
+
+  "mc_talking.debug.memory_header": "--- Citizen Memory: %s ---",
+
+  "mc_talking.debug.events_header": "--- Colony Events: %s (#%d) ---",
+
   "yacl3.config.mc_talking:config.category.api": "API",
   "yacl3.config.mc_talking:config.category.general": "General",
   "yacl3.config.mc_talking:config.category.citizens": "Citizens",


### PR DESCRIPTION
## Summary

Adds a `/talking_colonists` command tree with sub-commands for debugging the McTalking mod state. The old standalone `/list_tools` command has been moved under this root and the standalone registration removed.

### New sub-commands (all OP level 2)
- `status` — mod overview (API key, sessions, config toggles)
- `connections` — active Gemini sessions
- `citizen <target>` — colonist debug info
- `memory <target>` — stored citizen memories
- `events [colonyId]` — recent colony events
- `list_tools` — (moved from standalone command)

### Implementation details
- Follows existing Brigadier command pattern used by `ListToolsCommand`
- One file per sub-command in `commands/` package
- Added accessors to `ConversationManager` (4 methods) and `GeminiWsClient` (session start time) for debug data exposure
- Added `getRelationships()` to `CitizenMemories`

Closes #58