### PR TITLE
feat: memory compaction — periodic summarization of citizen memories

### DIFF
--- a/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
+++ b/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import me.sshcrack.gemini_live_lib.misc.GeminiTTS.AudioChunk;
+import me.sshcrack.mc_talking.conversations.memory.MemoryCompactionService;
 import me.sshcrack.mc_talking.pregen.HeatmapTracker;
 import me.sshcrack.mc_talking.pregen.PregenerationTaskService;
 import me.sshcrack.mc_talking.pregen.PregenerationPlayback;
@@ -84,6 +85,7 @@ public class ServerEventHandler {
      */
     @SubscribeEvent
     public void onServerStop(ServerStoppingEvent event) {
+        MemoryCompactionService.cleanup();
         PregenerationTaskService.cleanup();
         ConversationManager.cleanup();
         ColonyEventBuffer.clear();
@@ -203,6 +205,10 @@ public class ServerEventHandler {
 
         if (McTalkingConfig.INSTANCE.instance().enablePregeneration) {
             PregenerationTaskService.tick(server);
+        }
+
+        if (McTalkingConfig.INSTANCE.instance().enableMemoryCompaction) {
+            MemoryCompactionService.tick(server);
         }
     }
 

--- a/src/main/java/me/sshcrack/mc_talking/commands/DebugMemoryCommand.java
+++ b/src/main/java/me/sshcrack/mc_talking/commands/DebugMemoryCommand.java
@@ -61,6 +61,15 @@ public class DebugMemoryCommand {
                             .append(Component.literal(hasSessionToken ? "§a§lSET" : "§8none"))
                             .append(Component.literal("\n")));
 
+            // Summarized Memory (compaction)
+            String summarized = mem.getSummarizedMemory();
+            msg.append(Component.literal("  §7Summarized Memory (" + summarized.length() + " chars):\n"));
+            if (summarized.isBlank()) {
+                msg.append(Component.literal("    §8(none)\n"));
+            } else {
+                msg.append(Component.literal("    §f" + summarized + "\n"));
+            }
+
             // Facts
             msg.append(Component.literal("  §7Facts (" + facts.size() + "):\n"));
             if (facts.isEmpty()) {

--- a/src/main/java/me/sshcrack/mc_talking/commands/DebugStatusCommand.java
+++ b/src/main/java/me/sshcrack/mc_talking/commands/DebugStatusCommand.java
@@ -3,6 +3,8 @@ package me.sshcrack.mc_talking.commands;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import me.sshcrack.mc_talking.ConversationManager;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
+import me.sshcrack.mc_talking.conversations.memory.MemoryCompactionService;
+import me.sshcrack.mc_talking.pregen.PregenerationTaskService;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -26,6 +28,9 @@ public class DebugStatusCommand {
         int activeSessions = clients.size();
         int playerSessions = citizenToPlayer.size();
         int nonPlayerSessions = activeSessions - playerSessions;
+        int pregenActive = PregenerationTaskService.isPregenerating() ? 1 : 0;
+        int compactionActive = MemoryCompactionService.getActiveCount();
+        int totalActive = activeSessions + pregenActive + compactionActive;
         int maxAgents = config.maxConcurrentAgents;
         boolean hasKey = !config.geminiApiKey.isEmpty();
 
@@ -45,7 +50,7 @@ public class DebugStatusCommand {
             // Sessions
             msg.append(Component.literal("  "))
                     .append(Component.translatable("mc_talking.debug.status_sessions",
-                            activeSessions, maxAgents, playerSessions, nonPlayerSessions))
+                            totalActive, maxAgents, playerSessions, nonPlayerSessions, pregenActive, compactionActive))
                     .withStyle(ChatFormatting.WHITE)
                     .append(Component.literal("\n"));
 
@@ -76,7 +81,15 @@ public class DebugStatusCommand {
                     .append(Component.literal("\n"));
             msg.append(Component.literal("  "))
                     .append(Component.translatable("mc_talking.debug.status_pregeneration",
-                            McTalkingDebugCommand.booleanToStr(config.enablePregeneration)))
+                            McTalkingDebugCommand.booleanToStr(config.enablePregeneration),
+                            PregenerationTaskService.isPregenerating() ? "§aactive" : "§7idle"))
+                    .withStyle(ChatFormatting.GRAY)
+                    .append(Component.literal("\n"));
+            msg.append(Component.literal("  "))
+                    .append(Component.translatable("mc_talking.debug.status_compaction",
+                            McTalkingDebugCommand.booleanToStr(config.enableMemoryCompaction),
+                            config.memoryMode.name(),
+                            MemoryCompactionService.getActiveCount()))
                     .withStyle(ChatFormatting.GRAY);
 
             return msg;

--- a/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
+++ b/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
@@ -239,6 +239,27 @@ public class McTalkingConfig {
     @SerialEntry(comment = "If true, citizens will reference neighboring colonies and their diplomatic standing (allies, enemies, etc.) in conversations.")
     public boolean enableColonyDiplomacy = true;
 
+    // Memory Compaction
+    @AutoGen(category = "citizens", group = "memory")
+    @EnumCycler
+    @SerialEntry(comment = "How memory compaction is performed. LIVE uses a text-only WebSocket session. FLASH uses the Gemini Flash API.")
+    public MemoryMode memoryMode = MemoryMode.LIVE;
+
+    @AutoGen(category = "citizens", group = "memory")
+    @TickBox
+    @SerialEntry(comment = "If true, citizen memories will be periodically compacted and summarized to prevent unbounded growth.")
+    public boolean enableMemoryCompaction = true;
+
+    @AutoGen(category = "citizens", group = "memory")
+    @IntField(min = 20, max = 72000)
+    @SerialEntry(comment = "How often (in server ticks) to check for memory compaction candidates. 20 ticks = 1 second.")
+    public int memoryCompactionIntervalTicks = 100;
+
+    @AutoGen(category = "citizens", group = "memory")
+    @IntField(min = 1, max = 500)
+    @SerialEntry(comment = "Maximum number of individual events/facts before compaction is triggered for a citizen.")
+    public int memoryCompactionThreshold = 15;
+
     public static class ToolListFactory implements ListGroup.ValueFactory<String>, ListGroup.ControllerFactory<String> {
         @Override
         public String provideNewValue() {

--- a/src/main/java/me/sshcrack/mc_talking/config/MemoryMode.java
+++ b/src/main/java/me/sshcrack/mc_talking/config/MemoryMode.java
@@ -1,0 +1,14 @@
+package me.sshcrack.mc_talking.config;
+
+import dev.isxander.yacl3.api.NameableEnum;
+import net.minecraft.network.chat.Component;
+
+public enum MemoryMode implements NameableEnum {
+    LIVE,
+    FLASH;
+
+    @Override
+    public Component getDisplayName() {
+        return Component.literal(name());
+    }
+}

--- a/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionService.java
+++ b/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionService.java
@@ -7,6 +7,7 @@ import me.sshcrack.mc_talking.ConversationManager;
 import me.sshcrack.mc_talking.McTalking;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
 import me.sshcrack.mc_talking.config.MemoryMode;
+import me.sshcrack.mc_talking.conversations.memory.data.CitizenMemories;
 import me.sshcrack.mc_talking.duck.CitizenDataMemoryExtended;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -20,6 +21,16 @@ import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class MemoryCompactionService {
+    private MemoryCompactionService() {
+        /* This utility class should not be instantiated */
+    }
+
+    public static final String SYSTEM_PROMPT = """
+            You are a memory summarization assistant for a Minecraft colony citizen.\
+            Given the citizen's events and facts, produce a concise first-person summary.\
+            Retain solely permanent traits, lasting historical milestones, established relationships, and enduring social connections. \
+            Ensure all captured information remains true regardless of the current moment.\
+            OUTPUT THE SUMMARY IN PLAIN, UNFORMATTED TEXT""";
     private static final List<UUID> activeCompactionCitizens = new CopyOnWriteArrayList<>();
 
     private static int tickCounter = 0;
@@ -90,15 +101,16 @@ public class MemoryCompactionService {
     private static void startFlashCompaction(AbstractEntityCitizen citizen) {
         UUID citizenId = citizen.getUUID();
         activeCompactionCitizens.add(citizenId);
+        var data = (CitizenDataMemoryExtended) citizen.getCitizenData();
+        var mem = data.mc_talking$getOrInitializeMemory();
 
         Thread thread = new Thread(() -> {
             try {
                 String apiKey = McTalkingConfig.INSTANCE.instance().geminiApiKey;
-                String prompt = buildCompactionPrompt(citizen);
 
                 String responseText;
                 try {
-                    responseText = GeminiFlash.sendSimpleFlashRequest(McTalkingConfig.FLASH_MODEL, apiKey, prompt, "Generate the memory summary now.");
+                    responseText = GeminiFlash.sendSimpleFlashRequest(McTalkingConfig.FLASH_MODEL, apiKey, SYSTEM_PROMPT, buildPrompt(citizen, mem));
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     return;
@@ -115,10 +127,9 @@ public class MemoryCompactionService {
                     return;
                 }
 
-                String finalSummary = summary;
                 var server = citizen.level().getServer();
                 if (server != null) {
-                    server.execute(() -> applyCompaction(citizen, finalSummary));
+                    server.execute(() -> applyCompaction(citizen, summary));
                 }
             } finally {
                 activeCompactionCitizens.remove(citizenId);
@@ -166,39 +177,6 @@ public class MemoryCompactionService {
         }
     }
 
-    private static String buildCompactionPrompt(AbstractEntityCitizen citizen) {
-        String name = citizen.getCitizenData().getName();
-        var data = (CitizenDataMemoryExtended) citizen.getCitizenData();
-        var mem = data.mc_talking$getOrInitializeMemory();
-
-        StringBuilder sb = new StringBuilder();
-        sb.append("You are summarizing past memories for ").append(name)
-                .append(", a citizen of a Minecraft colony.\n\n");
-        sb.append("Keep only the most important information. Prioritize recent and significant events and facts.\n");
-        sb.append("Discard small talk and minor details. Write in first person from the citizen's perspective.\n\n");
-
-        if (!mem.getEvents().isEmpty()) {
-            sb.append("Events:\n");
-            for (String event : mem.getEvents()) {
-                sb.append("- ").append(event).append("\n");
-            }
-            sb.append("\n");
-        }
-
-        if (!mem.getFacts().isEmpty()) {
-            sb.append("Facts:\n");
-            for (String fact : mem.getFacts()) {
-                sb.append("- ").append(fact).append("\n");
-            }
-            sb.append("\n");
-        }
-
-        sb.append("Produce a single consolidated summary paragraph in first person.\n");
-        sb.append("Return ONLY the summary text, no labels or formatting.");
-
-        return sb.toString();
-    }
-
     private static String extractSummaryFromResponse(String response) {
         if (response == null) return null;
         response = response.trim();
@@ -230,11 +208,40 @@ public class MemoryCompactionService {
         // TODO: consider compacting stale relationship entries in the future
     }
 
+    public static int getActiveCount() {
+        return activeCompactionCitizens.size();
+    }
+
     public static void cleanup() {
         for (UUID citizenId : activeCompactionCitizens) {
             // Can't reliably release slots without the entity reference on shutdown
             McTalking.LOGGER.info("[MemoryCompaction] Cleanup: dropping active task for citizen {}", citizenId);
         }
         activeCompactionCitizens.clear();
+    }
+
+    static String buildPrompt(AbstractEntityCitizen citizen, CitizenMemories memories) {
+        String name = citizen.getCitizenData().getName();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Summarize these memories for ").append(name).append(":\n\n");
+
+        if (!memories.getEvents().isEmpty()) {
+            sb.append("Events:\n");
+            for (String event : memories.getEvents()) {
+                sb.append("- ").append(event).append("\n");
+            }
+            sb.append("\n");
+        }
+
+        if (!memories.getFacts().isEmpty()) {
+            sb.append("Facts:\n");
+            for (String fact : memories.getFacts()) {
+                sb.append("- ").append(fact).append("\n");
+            }
+            sb.append("\n");
+        }
+
+        sb.append("Summary:");
+        return sb.toString();
     }
 }

--- a/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionService.java
+++ b/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionService.java
@@ -1,0 +1,250 @@
+package me.sshcrack.mc_talking.conversations.memory;
+
+import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
+import me.sshcrack.gemini_live_lib.misc.GeminiFlash;
+import me.sshcrack.gemini_live_lib.misc.UnexpectedResponseException;
+import me.sshcrack.mc_talking.ConversationManager;
+import me.sshcrack.mc_talking.McTalking;
+import me.sshcrack.mc_talking.config.McTalkingConfig;
+import me.sshcrack.mc_talking.config.MemoryMode;
+import me.sshcrack.mc_talking.duck.CitizenDataMemoryExtended;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class MemoryCompactionService {
+    private static final List<UUID> activeCompactionCitizens = new CopyOnWriteArrayList<>();
+
+    private static int tickCounter = 0;
+
+    public static void tick(MinecraftServer server) {
+        tickCounter++;
+        int interval = McTalkingConfig.INSTANCE.instance().memoryCompactionIntervalTicks;
+        if (tickCounter % interval != 0) return;
+        if (!McTalkingConfig.INSTANCE.instance().enableCitizenMemory) return;
+        if (!McTalkingConfig.INSTANCE.instance().enableMemoryCompaction) return;
+        if (!activeCompactionCitizens.isEmpty()) return;
+
+        var candidate = findBestCandidate(server);
+        if (candidate == null) return;
+
+        startCompaction(candidate);
+    }
+
+    private static AbstractEntityCitizen findBestCandidate(MinecraftServer server) {
+        int threshold = McTalkingConfig.INSTANCE.instance().memoryCompactionThreshold;
+        List<AbstractEntityCitizen> candidates = new ArrayList<>();
+
+        for (ServerLevel level : server.getAllLevels()) {
+            for (Entity entity : level.getEntities().getAll()) {
+                if (!(entity instanceof AbstractEntityCitizen citizen)) continue;
+                if (citizen.getCitizenData() == null) continue;
+                if (ConversationManager.isCitizenBusy(citizen)) continue;
+
+                var data = (CitizenDataMemoryExtended) citizen.getCitizenData();
+                var mem = data.mc_talking$getOrInitializeMemory();
+
+                if (mem.getEvents().size() + mem.getFacts().size() >= threshold) {
+                    candidates.add(citizen);
+                }
+            }
+        }
+
+        if (candidates.isEmpty()) return null;
+
+        candidates.sort(Comparator.<AbstractEntityCitizen>comparingInt(
+                        c -> {
+                            var d = (CitizenDataMemoryExtended) c.getCitizenData();
+                            var m = d.mc_talking$getOrInitializeMemory();
+                            return m.getEvents().size() + m.getFacts().size();
+                        })
+                .reversed());
+
+        return candidates.get(0);
+    }
+
+    private static void startCompaction(AbstractEntityCitizen citizen) {
+        McTalking.LOGGER.info("[MemoryCompaction] Starting compaction for citizen {}",
+                citizen.getCitizenData().getName());
+
+        var data = (CitizenDataMemoryExtended) citizen.getCitizenData();
+        var mem = data.mc_talking$getOrInitializeMemory();
+
+        McTalking.LOGGER.info("[MemoryCompaction] Citizen {} has {} events and {} facts",
+                citizen.getCitizenData().getName(), mem.getEvents().size(), mem.getFacts().size());
+
+        if (McTalkingConfig.INSTANCE.instance().memoryMode == MemoryMode.FLASH) {
+            startFlashCompaction(citizen);
+        } else {
+            startLiveCompaction(citizen);
+        }
+    }
+
+    private static void startFlashCompaction(AbstractEntityCitizen citizen) {
+        UUID citizenId = citizen.getUUID();
+        activeCompactionCitizens.add(citizenId);
+
+        Thread thread = new Thread(() -> {
+            try {
+                String apiKey = McTalkingConfig.INSTANCE.instance().geminiApiKey;
+                String prompt = buildCompactionPrompt(citizen);
+
+                String responseText;
+                try {
+                    responseText = GeminiFlash.sendSimpleFlashRequest(McTalkingConfig.FLASH_MODEL, apiKey, prompt, "Generate the memory summary now.");
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                } catch (UnexpectedResponseException | IOException e) {
+                    McTalking.LOGGER.error("[MemoryCompaction] Flash request failed for citizen {}", citizen.getCitizenData().getName(), e);
+                    return;
+                } finally {
+                    activeCompactionCitizens.remove(citizenId);
+                }
+
+                String summary = extractSummaryFromResponse(responseText);
+                if (summary == null || summary.isBlank()) {
+                    McTalking.LOGGER.warn("[MemoryCompaction] Empty summary from Flash for citizen {}", citizen.getCitizenData().getName());
+                    return;
+                }
+
+                String finalSummary = summary;
+                var server = citizen.level().getServer();
+                if (server != null) {
+                    server.execute(() -> applyCompaction(citizen, finalSummary));
+                }
+            } finally {
+                activeCompactionCitizens.remove(citizenId);
+            }
+        }, "mc-talking-memory-flash-compaction");
+
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private static void startLiveCompaction(AbstractEntityCitizen citizen) {
+        UUID citizenId = citizen.getUUID();
+
+        if (!ConversationManager.hasFreeCapacity(1)) return;
+        if (!ConversationManager.claimSlot(citizen, false)) return;
+
+        activeCompactionCitizens.add(citizenId);
+
+        var data = (CitizenDataMemoryExtended) citizen.getCitizenData();
+        var mem = data.mc_talking$getOrInitializeMemory();
+
+        MemoryCompactionWsClient client = new MemoryCompactionWsClient(citizen, mem,
+                summary -> {
+                    activeCompactionCitizens.remove(citizenId);
+                    ConversationManager.releaseSlot(citizen);
+                    if (summary != null && !summary.isBlank()) {
+                        var server = citizen.level().getServer();
+                        if (server != null) {
+                            server.execute(() -> applyCompaction(citizen, summary));
+                        }
+                    }
+                },
+                () -> {
+                    activeCompactionCitizens.remove(citizenId);
+                    ConversationManager.releaseSlot(citizen);
+                    McTalking.LOGGER.warn("[MemoryCompaction] Live compaction failed for citizen {}", citizen.getCitizenData().getName());
+                });
+
+        try {
+            client.connect();
+        } catch (Exception e) {
+            McTalking.LOGGER.error("[MemoryCompaction] Failed to connect Live client for citizen {}", citizen.getCitizenData().getName(), e);
+            activeCompactionCitizens.remove(citizenId);
+            ConversationManager.releaseSlot(citizen);
+        }
+    }
+
+    private static String buildCompactionPrompt(AbstractEntityCitizen citizen) {
+        String name = citizen.getCitizenData().getName();
+        var data = (CitizenDataMemoryExtended) citizen.getCitizenData();
+        var mem = data.mc_talking$getOrInitializeMemory();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("You are summarizing past memories for ").append(name)
+                .append(", a citizen of a Minecraft colony.\n\n");
+        sb.append("Keep only the most important information. Prioritize recent and significant events and facts.\n");
+        sb.append("Discard small talk and minor details. Write in first person from the citizen's perspective.\n\n");
+
+        if (!mem.getEvents().isEmpty()) {
+            sb.append("Events:\n");
+            for (String event : mem.getEvents()) {
+                sb.append("- ").append(event).append("\n");
+            }
+            sb.append("\n");
+        }
+
+        if (!mem.getFacts().isEmpty()) {
+            sb.append("Facts:\n");
+            for (String fact : mem.getFacts()) {
+                sb.append("- ").append(fact).append("\n");
+            }
+            sb.append("\n");
+        }
+
+        sb.append("Produce a single consolidated summary paragraph in first person.\n");
+        sb.append("Return ONLY the summary text, no labels or formatting.");
+
+        return sb.toString();
+    }
+
+    private static String extractSummaryFromResponse(String response) {
+        if (response == null) return null;
+        response = response.trim();
+        if (response.startsWith("```")) {
+            int start = response.indexOf('\n');
+            int end = response.lastIndexOf("```");
+            if (start > 0 && end > start) {
+                response = response.substring(start, end).trim();
+            }
+        }
+        return response;
+    }
+
+    private static void applyCompaction(AbstractEntityCitizen citizen, String summary) {
+        if (!citizen.isAlive()) return;
+        var data = (CitizenDataMemoryExtended) citizen.getCitizenData();
+        if (data == null) return;
+
+        var mem = data.mc_talking$getOrInitializeMemory();
+        int eventCount = mem.getEvents().size();
+        int factCount = mem.getFacts().size();
+
+        McTalking.LOGGER.info("[MemoryCompaction] Applied compaction for citizen {} ({} events + {} facts -> {} chars)",
+                citizen.getCitizenData().getName(), eventCount, factCount, summary.length());
+
+        mem.setSummarizedMemory(summary);
+        mem.getEvents().clear();
+        mem.getFacts().clear();
+        // TODO: consider compacting stale relationship entries in the future
+    }
+
+    public static void cleanup() {
+        for (UUID citizenId : activeCompactionCitizens) {
+            // Can't reliably release slots without the entity reference on shutdown
+            McTalking.LOGGER.info("[MemoryCompaction] Cleanup: dropping active task for citizen {}", citizenId);
+        }
+        activeCompactionCitizens.clear();
+    }
+
+    private static AbstractEntityCitizen findCitizen(MinecraftServer server, UUID uuid) {
+        for (ServerLevel level : server.getAllLevels()) {
+            Entity entity = level.getEntity(uuid);
+            if (entity instanceof AbstractEntityCitizen citizen) {
+                return citizen;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionService.java
+++ b/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionService.java
@@ -28,7 +28,7 @@ public class MemoryCompactionService {
         tickCounter++;
         int interval = McTalkingConfig.INSTANCE.instance().memoryCompactionIntervalTicks;
         if (tickCounter % interval != 0) return;
-        if (!McTalkingConfig.INSTANCE.instance().enableCitizenMemory) return;
+        if (McTalkingConfig.INSTANCE.instance().enableConversationSummaryAndMemorize) return;
         if (!McTalkingConfig.INSTANCE.instance().enableMemoryCompaction) return;
         if (!activeCompactionCitizens.isEmpty()) return;
 
@@ -236,15 +236,5 @@ public class MemoryCompactionService {
             McTalking.LOGGER.info("[MemoryCompaction] Cleanup: dropping active task for citizen {}", citizenId);
         }
         activeCompactionCitizens.clear();
-    }
-
-    private static AbstractEntityCitizen findCitizen(MinecraftServer server, UUID uuid) {
-        for (ServerLevel level : server.getAllLevels()) {
-            Entity entity = level.getEntity(uuid);
-            if (entity instanceof AbstractEntityCitizen citizen) {
-                return citizen;
-            }
-        }
-        return null;
     }
 }

--- a/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionWsClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionWsClient.java
@@ -8,9 +8,9 @@ import me.sshcrack.gemini_live_lib.gson.ClientMessages;
 import me.sshcrack.gemini_live_lib.gson.RealtimeInput;
 import me.sshcrack.mc_talking.McTalking;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
+import me.sshcrack.mc_talking.config.ModalityModes;
 import me.sshcrack.mc_talking.conversations.memory.data.CitizenMemories;
 
-import java.util.List;
 import java.util.function.Consumer;
 
 public class MemoryCompactionWsClient extends GeminiLiveClient {
@@ -19,6 +19,7 @@ public class MemoryCompactionWsClient extends GeminiLiveClient {
     private final Consumer<String> onComplete;
     private final Runnable onError;
     private final StringBuilder summaryBuffer = new StringBuilder();
+    private volatile boolean completed = false;
 
     public MemoryCompactionWsClient(AbstractEntityCitizen citizen, CitizenMemories memories,
                                     Consumer<String> onComplete, Runnable onError) {
@@ -33,14 +34,25 @@ public class MemoryCompactionWsClient extends GeminiLiveClient {
     public BidiGenerateContentSetup getSetup() {
         var setup = new BidiGenerateContentSetup("models/" + McTalkingConfig.INSTANCE.instance().currentAiModel.getName());
 
-        setup.generationConfig.responseModalities = List.of("TEXT", "AUDIO");
+        setup.generationConfig.responseModalities = ModalityModes.TEXT_AND_AUDIO.getModalities();
+        setup.outputAudioTranscription = new JsonObject();
+
+        var citizenData = citizen.getCitizenData();
+        if (citizenData != null) {
+            setup.generationConfig.speechConfig = new BidiGenerateContentSetup.GenerationConfig.SpeechConfig();
+            setup.generationConfig.speechConfig.language_code = McTalkingConfig.INSTANCE.instance().language;
+            var female = citizenData.isFemale();
+            var uuid = citizen.getUUID();
+            setup.generationConfig.speechConfig.voice_config = new BidiGenerateContentSetup.GenerationConfig.SpeechConfig.VoiceConfig();
+            setup.generationConfig.speechConfig.voice_config.prebuiltVoiceConfig = new BidiGenerateContentSetup.GenerationConfig.SpeechConfig.PrebuiltVoiceConfig();
+            setup.generationConfig.speechConfig.voice_config.prebuiltVoiceConfig.voice_name = McTalkingConfig.INSTANCE.instance().currentAiModel.getRandomVoice(uuid, female);
+        }
+
+        setup.realtimeInputConfig = new BidiGenerateContentSetup.RealtimeInputConfig();
 
         var sys = new BidiGenerateContentSetup.SystemInstruction();
         var p = new BidiGenerateContentSetup.SystemInstruction.Part(
-                "You are a memory summarization assistant for a Minecraft colony citizen. " +
-                        "Given the citizen's events and facts, produce a concise first-person summary. " +
-                        "Keep recent and significant information. Discard minor details. " +
-                        "Output only the summary text, no labels or formatting."
+                MemoryCompactionService.SYSTEM_PROMPT
         );
         sys.parts.add(p);
         setup.systemInstruction = sys;
@@ -50,35 +62,9 @@ public class MemoryCompactionWsClient extends GeminiLiveClient {
 
     @Override
     public void onSetupComplete() {
-        String prompt = buildPrompt();
         var input = new RealtimeInput();
-        input.text = prompt;
+        input.text = MemoryCompactionService.buildPrompt(citizen, memories);
         send(ClientMessages.input(input));
-    }
-
-    private String buildPrompt() {
-        String name = citizen.getCitizenData().getName();
-        StringBuilder sb = new StringBuilder();
-        sb.append("Summarize these memories for ").append(name).append(":\n\n");
-
-        if (!memories.getEvents().isEmpty()) {
-            sb.append("Events:\n");
-            for (String event : memories.getEvents()) {
-                sb.append("- ").append(event).append("\n");
-            }
-            sb.append("\n");
-        }
-
-        if (!memories.getFacts().isEmpty()) {
-            sb.append("Facts:\n");
-            for (String fact : memories.getFacts()) {
-                sb.append("- ").append(fact).append("\n");
-            }
-            sb.append("\n");
-        }
-
-        sb.append("Summary:");
-        return sb.toString();
     }
 
     @Override
@@ -88,14 +74,17 @@ public class MemoryCompactionWsClient extends GeminiLiveClient {
 
     @Override
     public void onGeneratedAudio(byte[] data, int sampleRate) {
+        // We don't process audio and don't expect it
     }
 
     @Override
     public void onOutputTranscription(String transcription) {
+        summaryBuffer.append(transcription);
     }
 
     @Override
     public void onTurnComplete() {
+        completed = true;
         String summary = summaryBuffer.toString().trim();
         if (summary.isEmpty()) {
             McTalking.LOGGER.warn("[MemoryCompaction] Live client produced empty summary for citizen {}",
@@ -127,6 +116,17 @@ public class MemoryCompactionWsClient extends GeminiLiveClient {
     }
 
     @Override
+    public void onClose(int code, String reason, boolean remote) {
+        super.onClose(code, reason, remote);
+        if (!completed) {
+            McTalking.LOGGER.warn("[MemoryCompaction] Unexpected close for citizen {} (code={}, reason={}, remote={})",
+                    citizen.getCitizenData().getName(), code, reason, remote);
+            onError.run();
+        }
+    }
+
+    @Override
     public void addPromptAudio(short[] audio) {
+        // We don't want to add prompt audio
     }
 }

--- a/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionWsClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionWsClient.java
@@ -1,0 +1,132 @@
+package me.sshcrack.mc_talking.conversations.memory;
+
+import com.google.gson.JsonObject;
+import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
+import me.sshcrack.gemini_live_lib.GeminiLiveClient;
+import me.sshcrack.gemini_live_lib.gson.BidiGenerateContentSetup;
+import me.sshcrack.gemini_live_lib.gson.ClientMessages;
+import me.sshcrack.gemini_live_lib.gson.RealtimeInput;
+import me.sshcrack.mc_talking.McTalking;
+import me.sshcrack.mc_talking.config.McTalkingConfig;
+import me.sshcrack.mc_talking.conversations.memory.data.CitizenMemories;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public class MemoryCompactionWsClient extends GeminiLiveClient {
+    private final AbstractEntityCitizen citizen;
+    private final CitizenMemories memories;
+    private final Consumer<String> onComplete;
+    private final Runnable onError;
+    private final StringBuilder summaryBuffer = new StringBuilder();
+
+    public MemoryCompactionWsClient(AbstractEntityCitizen citizen, CitizenMemories memories,
+                                    Consumer<String> onComplete, Runnable onError) {
+        super(McTalkingConfig.INSTANCE.instance().geminiApiKey);
+        this.citizen = citizen;
+        this.memories = memories;
+        this.onComplete = onComplete;
+        this.onError = onError;
+    }
+
+    @Override
+    public BidiGenerateContentSetup getSetup() {
+        var setup = new BidiGenerateContentSetup("models/" + McTalkingConfig.INSTANCE.instance().currentAiModel.getName());
+
+        setup.generationConfig.responseModalities = List.of("TEXT", "AUDIO");
+
+        var sys = new BidiGenerateContentSetup.SystemInstruction();
+        var p = new BidiGenerateContentSetup.SystemInstruction.Part(
+                "You are a memory summarization assistant for a Minecraft colony citizen. " +
+                        "Given the citizen's events and facts, produce a concise first-person summary. " +
+                        "Keep recent and significant information. Discard minor details. " +
+                        "Output only the summary text, no labels or formatting."
+        );
+        sys.parts.add(p);
+        setup.systemInstruction = sys;
+
+        return setup;
+    }
+
+    @Override
+    public void onSetupComplete() {
+        String prompt = buildPrompt();
+        var input = new RealtimeInput();
+        input.text = prompt;
+        send(ClientMessages.input(input));
+    }
+
+    private String buildPrompt() {
+        String name = citizen.getCitizenData().getName();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Summarize these memories for ").append(name).append(":\n\n");
+
+        if (!memories.getEvents().isEmpty()) {
+            sb.append("Events:\n");
+            for (String event : memories.getEvents()) {
+                sb.append("- ").append(event).append("\n");
+            }
+            sb.append("\n");
+        }
+
+        if (!memories.getFacts().isEmpty()) {
+            sb.append("Facts:\n");
+            for (String fact : memories.getFacts()) {
+                sb.append("- ").append(fact).append("\n");
+            }
+            sb.append("\n");
+        }
+
+        sb.append("Summary:");
+        return sb.toString();
+    }
+
+    @Override
+    public void onGeneratedText(String text) {
+        summaryBuffer.append(text);
+    }
+
+    @Override
+    public void onGeneratedAudio(byte[] data, int sampleRate) {
+    }
+
+    @Override
+    public void onOutputTranscription(String transcription) {
+    }
+
+    @Override
+    public void onTurnComplete() {
+        String summary = summaryBuffer.toString().trim();
+        if (summary.isEmpty()) {
+            McTalking.LOGGER.warn("[MemoryCompaction] Live client produced empty summary for citizen {}",
+                    citizen.getCitizenData().getName());
+            onError.run();
+        } else {
+            onComplete.accept(summary);
+        }
+        close();
+    }
+
+    @Override
+    public JsonObject onFunctionCall(String name, JsonObject args) {
+        return null;
+    }
+
+    @Override
+    public void onQuotaExceeded() {
+        McTalking.LOGGER.warn("[MemoryCompaction] Quota exceeded during Live compaction");
+        onError.run();
+        close();
+    }
+
+    @Override
+    public void onError(Exception ex) {
+        McTalking.LOGGER.error("[MemoryCompaction] Error during Live compaction", ex);
+        onError.run();
+        close();
+    }
+
+    @Override
+    public void addPromptAudio(short[] audio) {
+    }
+}

--- a/src/main/java/me/sshcrack/mc_talking/conversations/memory/data/CitizenMemories.java
+++ b/src/main/java/me/sshcrack/mc_talking/conversations/memory/data/CitizenMemories.java
@@ -16,10 +16,12 @@ public class CitizenMemories {
     private static final String TAG_EVENTS_KEY = "events";
     private static final String TAG_RELATIONSHIPS_KEY = "relationships";
     private static final String TAG_SESSION_TOKEN = "gemini_session_token";
+    private static final String TAG_SUMMARIZED_MEMORY = "summarized_memory";
     private final List<String> facts = new ArrayList<>();
     private final List<String> events = new ArrayList<>();
     private final List<CitizenRelationshipMemory> relationships = new ArrayList<>();
     private String sessionToken = "";
+    private String summarizedMemory = "";
 
     public CitizenMemories() {
         // We do not initialize these memories because at first it is empty.
@@ -53,6 +55,14 @@ public class CitizenMemories {
      * @param type       the type of relationship change (e.g. trust, friendship, etc.)
      * @param change     the amount of change to apply to the relationship (positive or negative)
      */
+    public void setSummarizedMemory(String summarizedMemory) {
+        this.summarizedMemory = summarizedMemory == null ? "" : summarizedMemory;
+    }
+
+    public String getSummarizedMemory() {
+        return summarizedMemory == null ? "" : summarizedMemory;
+    }
+
     public void addRelationshipChange(@NotNull UUID targetUUID, @NotNull CitizenRelationshipChangeType type, float change) {
         for (CitizenRelationshipMemory relationship : relationships) {
             if (relationship.getTargetUUID().equals(targetUUID) && relationship.getType() == type) {
@@ -88,6 +98,9 @@ public class CitizenMemories {
         if (sessionToken != null && !sessionToken.isBlank()) {
             tag.putString(TAG_SESSION_TOKEN, sessionToken);
         }
+        if (!summarizedMemory.isBlank()) {
+            tag.putString(TAG_SUMMARIZED_MEMORY, summarizedMemory);
+        }
         return tag;
     }
 
@@ -115,6 +128,9 @@ public class CitizenMemories {
         if (tag.contains(TAG_SESSION_TOKEN)) {
             sessionToken = tag.getString(TAG_SESSION_TOKEN);
         }
+        if (tag.contains(TAG_SUMMARIZED_MEMORY)) {
+            summarizedMemory = tag.getString(TAG_SUMMARIZED_MEMORY);
+        }
     }
 
     public String getSessionToken() {
@@ -133,17 +149,23 @@ public class CitizenMemories {
      */
     public String toPrompt(Map<UUID, String> interestedParties) {
         StringBuilder prompt = new StringBuilder();
-        if (!facts.isEmpty()) {
-            prompt.append(" Facts:\n");
-            for (String fact : facts) {
-                prompt.append("- ").append(fact).append("\n");
-            }
+
+        if (!summarizedMemory.isBlank()) {
+            prompt.append(" Summarized Memory:\n");
+            prompt.append(" ").append(summarizedMemory).append("\n\n");
         }
 
         if (!events.isEmpty()) {
-            prompt.append(" Events:\n");
+            prompt.append(" Recent Events:\n");
             for (String event : events) {
                 prompt.append("- ").append(event).append("\n");
+            }
+        }
+
+        if (!facts.isEmpty()) {
+            prompt.append(" Recent Facts:\n");
+            for (String fact : facts) {
+                prompt.append("- ").append(fact).append("\n");
             }
         }
 

--- a/src/main/java/me/sshcrack/mc_talking/conversations/memory/data/CitizenMemories.java
+++ b/src/main/java/me/sshcrack/mc_talking/conversations/memory/data/CitizenMemories.java
@@ -48,19 +48,12 @@ public class CitizenMemories {
         events.add(event);
     }
 
-    /**
-     * Adds a relationship change to the memories. If a change for the same citizen and relationship type already exists, it will be updated instead of adding a new entry.
-     *
-     * @param targetUUID the UUID of the other citizen or the affected player
-     * @param type       the type of relationship change (e.g. trust, friendship, etc.)
-     * @param change     the amount of change to apply to the relationship (positive or negative)
-     */
     public void setSummarizedMemory(String summarizedMemory) {
         this.summarizedMemory = summarizedMemory == null ? "" : summarizedMemory;
     }
 
     public String getSummarizedMemory() {
-        return summarizedMemory == null ? "" : summarizedMemory;
+        return summarizedMemory;
     }
 
     public void addRelationshipChange(@NotNull UUID targetUUID, @NotNull CitizenRelationshipChangeType type, float change) {

--- a/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationTaskService.java
+++ b/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationTaskService.java
@@ -225,6 +225,10 @@ public class PregenerationTaskService {
         return friends != null && friends.containsKey(friendId);
     }
 
+    public static boolean isPregenerating() {
+        return isGenerating;
+    }
+
     public static void cleanup() {
         lastThreatPlayTime.clear();
         isGenerating = false;

--- a/src/main/resources/assets/mc_talking/lang/en_us.json
+++ b/src/main/resources/assets/mc_talking/lang/en_us.json
@@ -71,12 +71,13 @@
 
   "mc_talking.debug.status_header": "--- McTalking Status ---",
   "mc_talking.debug.api_key_status": "API Key: %s",
-  "mc_talking.debug.status_sessions": "Sessions: %d/%d (%d player, %d non-player)",
+  "mc_talking.debug.status_sessions": "Sessions: %d/%d (%d player, %d non-player, %d pregen, %d compaction)",
   "mc_talking.debug.status_cooldown": "Cooldown: %s",
   "mc_talking.debug.status_memory": "Memory: %s",
   "mc_talking.debug.status_personality": "Personality: %s",
   "mc_talking.debug.status_citizen_to_citizen": "Citizen-to-Citizen: %s",
-  "mc_talking.debug.status_pregeneration": "Pregeneration: %s",
+  "mc_talking.debug.status_pregeneration": "Pregeneration: %s (%s)",
+  "mc_talking.debug.status_compaction": "MemCompaction: %s [%s] (%d active)",
 
   "mc_talking.debug.connections_header": "--- Active Connections (%d) ---",
 


### PR DESCRIPTION
## Problem

Citizen memories (`CitizenMemories.facts` and `CitizenMemories.events`) are stored as plain `ArrayList<String>` that grow unboundedly with every conversation. There is **no** summarization, pruning, or cleanup mechanism. Over time:

- The `toPrompt()` output grows linearly with conversation count
- Old, irrelevant events accumulate alongside important new ones
- The AI prompt becomes bloated and may exceed context window limits
- Early events (often very verbose) dominate the memory prompt forever

## Solution

This PR adds an automatic **memory compaction** system that periodically summarizes and consolidates old memories:

### New Config Options (in `McTalkingConfig.java`)
- `memoryMode`: Enum — `LIVE` (default, uses Gemini Live WebSocket) or `FLASH` (uses Gemini Flash API)
- `enableMemoryCompaction`: Master toggle (default: true)
- `memoryCompactionIntervalTicks`: How often to check (default: 100 ticks = 5 seconds)
- `memoryCompactionThreshold`: Event+fact count that triggers compaction (default: 15)

### New Classes
- `MemoryCompactionService` — Periodic tick-based service (runs every 5s). Scans all loaded citizens, sorts by memory size (most first), triggers compaction via LIVE or FLASH mode. Only processes one citizen per interval.
- `MemoryCompactionWsClient` — Gemini Live WebSocket client for LIVE mode. Uses TEXT_AND_AUDIO modality (audio output ignored), sends a summarization prompt, collects the response transcript via `onOutputTranscription()`.

### Data Model Changes (`CitizenMemories`)
- Added `summarizedMemory` field — a single consolidated text block replacing the old events+facts after compaction
- `toPrompt()` now shows: **Summarized Memory** first, then **Recent Events**, then **Recent Facts**
- After compaction, the events/facts lists are cleared — new entries added by the AI tool accumulate until the next cycle
- NBT serialization/deserialization includes the new field

### Prompt Priority
- Citizens with the most events+facts are processed first
- Compaction handles both events and facts (relationships left untouched with a TODO)
- LIVE mode only uses free slots (`hasFreeCapacity()`), never evicts other sessions
- `MemoryCompactionWsClient` has proper `onClose` handling for unexpected disconnects

### Debug Commands
- `/talking_colonists status` now shows pregeneration and compaction status with active counts
- `/talking_colonists memory` now shows the summarized memory block
- Session count in status includes pregen + compaction in the total

## Closes
Closes #60