### PR TITLE
feat: walk to player on urgent contact

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ publish.github=true
 
 deps.voicechat_api_version=2.6.0
 deps.voice_chat=2.6.16
-deps.gemini_live_lib_version=2.3.2
+deps.gemini_live_lib_version=2.3.3
 deps.yacl_version=3.6.6

--- a/src/main/java/me/sshcrack/mc_talking/ConversationManager.java
+++ b/src/main/java/me/sshcrack/mc_talking/ConversationManager.java
@@ -1,5 +1,6 @@
 package me.sshcrack.mc_talking;
 
+import com.minecolonies.api.entity.ai.JobStatus;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.core.entity.visitor.VisitorCitizen;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
@@ -15,8 +16,10 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -70,6 +73,13 @@ public class ConversationManager {
      * {@link me.sshcrack.mc_talking.config.McTalkingConfig#citizenCooldownSeconds}.
      */
     private static final Map<UUID, Long> lastSessionEndTime = new ConcurrentHashMap<>();
+
+    /**
+     * citizenId → need signature captured when the cooldown was recorded.
+     * If the citizen's current need signature differs, the cooldown is cleared
+     * so they can immediately contact about a new problem.
+     */
+    private static final Map<UUID, String> lastSessionNeedSignatures = new ConcurrentHashMap<>();
 
     /**
      * Insertion-ordered queue of all occupied citizen slots.
@@ -268,17 +278,76 @@ public class ConversationManager {
      */
     public static void recordCooldown(AbstractEntityCitizen citizen) {
         lastSessionEndTime.put(citizen.getUUID(), System.currentTimeMillis());
+        lastSessionNeedSignatures.put(citizen.getUUID(), computeNeedSignature(citizen));
     }
 
     /**
      * Returns {@code true} if the citizen is still within their cooldown period and
      * should not be selected for a new automatic (mumble / citizen-to-citizen) session.
+     *
+     * <p>If the citizen's current needs differ from when the cooldown was recorded,
+     * the cooldown is cleared so they can immediately contact about the new problem.</p>
      */
     public static boolean isCitizenOnCooldown(AbstractEntityCitizen citizen) {
-        Long lastEnd = lastSessionEndTime.get(citizen.getUUID());
+        UUID citizenId = citizen.getUUID();
+        Long lastEnd = lastSessionEndTime.get(citizenId);
         if (lastEnd == null) return false;
+
+        // Check if the citizen's needs have changed since cooldown was recorded
+        String prevSignature = lastSessionNeedSignatures.get(citizenId);
+        String currentSignature = computeNeedSignature(citizen);
+        if (prevSignature != null && !prevSignature.equals(currentSignature)) {
+            lastSessionEndTime.remove(citizenId);
+            lastSessionNeedSignatures.remove(citizenId);
+            return false;
+        }
+
         long cooldownMs = McTalkingConfig.INSTANCE.instance().citizenCooldownSeconds * 1000L;
         return (System.currentTimeMillis() - lastEnd) < cooldownMs;
+    }
+
+    /**
+     * Computes a signature string representing the citizen's current urgent needs.
+     * If this signature changes between sessions, the cooldown is cleared so the
+     * citizen can immediately contact about a new problem.
+     */
+    public static String computeNeedSignature(AbstractEntityCitizen citizen) {
+        var data = citizen.getCitizenData();
+        if (data == null) return "none";
+
+        List<String> needs = new ArrayList<>();
+
+        if (data.getJobStatus() == JobStatus.STUCK) needs.add("stuck");
+        if (data.getCitizenDiseaseHandler().isSick()) needs.add("sick");
+
+        double saturation = data.getSaturation();
+        if (saturation <= 1) {
+            needs.add("starving");
+        } else if (saturation <= 3) {
+            needs.add("hungry");
+        }
+
+        if (data.getHomeBuilding() == null) needs.add("homeless");
+
+        double happiness = data.getCitizenHappinessHandler().getHappiness(data.getColony(), data);
+        if (happiness < 3.0) {
+            needs.add("very_unhappy");
+        } else if (happiness < 5.0) {
+            needs.add("unhappy");
+        }
+
+        var entityOpt = data.getEntity();
+        if (entityOpt.isPresent()) {
+            double healthPercent = (entityOpt.get().getHealth() / Math.max(1.0, entityOpt.get().getMaxHealth())) * 100.0;
+            if (healthPercent < 25.0) {
+                needs.add("low_health");
+            } else if (healthPercent < 50.0) {
+                needs.add("medium_health");
+            }
+        }
+
+        if (needs.isEmpty()) needs.add("none");
+        return String.join(",", needs);
     }
 
     // -------------------------------------------------------------------------
@@ -493,6 +562,7 @@ public class ConversationManager {
         citizenToPlayer.clear();
         addedEntities.clear();
         lastSessionEndTime.clear();
+        lastSessionNeedSignatures.clear();
         GeminiWsClient.shutdownExecutor();
     }
 }

--- a/src/main/java/me/sshcrack/mc_talking/ConversationManager.java
+++ b/src/main/java/me/sshcrack/mc_talking/ConversationManager.java
@@ -134,7 +134,10 @@ public class ConversationManager {
      * Use when the client is already closed externally.
      */
     public static synchronized void releaseSlot(AbstractEntityCitizen citizen) {
-        UUID entityId = citizen.getUUID();
+        releaseSlot(citizen.getUUID());
+    }
+
+    public static synchronized void releaseSlot(UUID entityId) {
         if (addedEntities.remove(entityId)) {
             McTalking.LOGGER.info("[ConversationManager] Freed slot for entity {}", entityId);
         }

--- a/src/main/java/me/sshcrack/mc_talking/McTalkingVoicechatPlugin.java
+++ b/src/main/java/me/sshcrack/mc_talking/McTalkingVoicechatPlugin.java
@@ -9,6 +9,7 @@ import de.maxhenkel.voicechat.api.events.EventRegistration;
 import de.maxhenkel.voicechat.api.events.MicrophonePacketEvent;
 import de.maxhenkel.voicechat.api.events.VoicechatServerStartedEvent;
 import de.maxhenkel.voicechat.api.events.VoicechatServerStoppedEvent;
+import me.sshcrack.mc_talking.config.ModalityModes;
 import me.sshcrack.mc_talking.conversations.memory.CitizenMemoryGenerator;
 import me.sshcrack.mc_talking.conversations.memory.PlayerConversationMemoryGenerator;
 import me.sshcrack.mc_talking.manager.GeminiWsClient;
@@ -317,5 +318,10 @@ public class McTalkingVoicechatPlugin implements VoicechatPlugin {
                 }
             }
         }
+    }
+
+    public static boolean shouldDisableColoniesTicks(ServerPlayer player) {
+        var conn = vcApi.getConnectionOf(player.getUUID());
+        return conn != null && conn.isDisabled() && McTalkingConfig.INSTANCE.instance().modality == ModalityModes.AUDIO;
     }
 }

--- a/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
+++ b/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
@@ -72,6 +72,9 @@ public class ServerEventHandler {
     private record WalkingTarget(UUID playerId, int lastRepathTick) {}
     private final Map<UUID, WalkingTarget> walkingCitizens = new HashMap<>();
 
+    /** playerId → System.currentTimeMillis() of the last urgent contact for that player. */
+    private final Map<UUID, Long> lastPlayerUrgentContactTimes = new HashMap<>();
+
     /**
      * Called when the server starts
      */
@@ -105,6 +108,7 @@ public class ServerEventHandler {
             abortWalking(citizenId, server);
         }
         walkingCitizens.clear();
+        lastPlayerUrgentContactTimes.clear();
     }
 
     /**
@@ -182,8 +186,7 @@ public class ServerEventHandler {
         for (ServerPlayer player : activePlayers) {
 
             UUID playerId = player.getUUID();
-            var conn = McTalkingVoicechatPlugin.vcApi.getConnectionOf(player.getUUID());
-            if (conn != null && conn.isDisabled())
+            if (McTalkingVoicechatPlugin.shouldDisableColoniesTicks(player))
                 continue;
 
             double range = McTalkingConfig.INSTANCE.instance().mumblingDetectionRange;
@@ -195,16 +198,16 @@ public class ServerEventHandler {
                 PlayerHeatmapTracker.recordProximity(player.getUUID(), citizen.getUUID());
             }
 
-            var anyBusy = citizens.stream().anyMatch(ConversationManager::isCitizenBusy);
-            if (anyBusy)
-                continue;
-
             if (doDistanceCheck) {
                 checkConversationDistance(player);
                 if (McTalkingConfig.INSTANCE.instance().enableUrgentContactWalkToPlayer) {
                     checkUrgentContactAbort(player);
                 }
             }
+
+            var anyBusy = citizens.stream().anyMatch(ConversationManager::isCitizenBusy);
+            if (anyBusy)
+                continue;
 
             AbstractEntityCitizen talkingCitizen = ConversationManager.getActiveEntityForPlayer(player.getUUID());
             if (talkingCitizen != null
@@ -362,6 +365,16 @@ public class ServerEventHandler {
     private void checkForCitizenInitiatedContact(ServerPlayer player, List<AbstractEntityCitizen> citizens,
                                                    Set<UUID> contactedThisInterval) {
         if (McTalkingConfig.INSTANCE.instance().geminiApiKey.isEmpty()) return;
+
+        // Per-player urgent contact cooldown: prevent spam from multiple citizens
+        int playerCooldownSecs = McTalkingConfig.INSTANCE.instance().playerUrgentContactCooldownSeconds;
+        if (playerCooldownSecs > 0) {
+            Long lastContact = lastPlayerUrgentContactTimes.get(player.getUUID());
+            if (lastContact != null && (System.currentTimeMillis() - lastContact) / 1000L < playerCooldownSecs) {
+                return;
+            }
+        }
+
         double baseChance = McTalkingConfig.INSTANCE.instance().citizenContactBaseChance;
         boolean walkToPlayer = McTalkingConfig.INSTANCE.instance().enableUrgentContactWalkToPlayer;
 
@@ -388,6 +401,9 @@ public class ServerEventHandler {
                         citizen.getCitizenData().getName(),
                         walkToPlayer ? "walk-to-player" : "contact",
                         player.getName().getString());
+
+                // Record per-player cooldown timestamp
+                lastPlayerUrgentContactTimes.put(player.getUUID(), System.currentTimeMillis());
 
                 if (walkToPlayer) {
                     startWalkingUrgentContact(citizen, player);
@@ -460,7 +476,7 @@ public class ServerEventHandler {
 
         citizen.getNavigation().moveTo(player, McTalkingConfig.CITIZEN_URGENT_WALK_SPEED);
 
-        McTalking.LOGGER.info("[CitizenContact] Citizen {} walking to player {}", 
+        McTalking.LOGGER.info("[CitizenContact] Citizen {} walking to player {}",
                 citizen.getCitizenData().getName(), player.getName().getString());
     }
 

--- a/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
+++ b/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
@@ -1,6 +1,7 @@
 package me.sshcrack.mc_talking;
 
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
+import com.minecolonies.api.entity.ai.JobStatus;
 import me.sshcrack.mc_talking.commands.McTalkingDebugCommand;
 import me.sshcrack.mc_talking.conversations.CitizenConversation;
 import me.sshcrack.mc_talking.item.CitizenTalkingDevice;
@@ -14,10 +15,14 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+
+import org.jetbrains.annotations.Nullable;
 
 import me.sshcrack.gemini_live_lib.misc.GeminiTTS.AudioChunk;
 import me.sshcrack.mc_talking.pregen.HeatmapTracker;
@@ -64,6 +69,9 @@ import net.minecraftforge.fml.common.Mod;
 public class ServerEventHandler {
     private int tickCounter = 0;
 
+    private record WalkingTarget(UUID playerId, int lastRepathTick) {}
+    private final Map<UUID, WalkingTarget> walkingCitizens = new HashMap<>();
+
     /**
      * Called when the server starts
      */
@@ -91,6 +99,12 @@ public class ServerEventHandler {
         ConversationManager.cleanup();
         ColonyEventBuffer.clear();
         PlayerHeatmapTracker.cleanup();
+
+        MinecraftServer server = event.getServer();
+        for (UUID citizenId : walkingCitizens.keySet()) {
+            abortWalking(citizenId, server);
+        }
+        walkingCitizens.clear();
     }
 
     /**
@@ -124,6 +138,15 @@ public class ServerEventHandler {
         if (event.getEntity() instanceof ServerPlayer player) {
             ConversationManager.endConversation(player.getUUID(), false);
             PlayerHeatmapTracker.onPlayerRemoved(player.getUUID());
+
+            MinecraftServer server = player.getServer();
+            walkingCitizens.entrySet().removeIf(entry -> {
+                if (entry.getValue().playerId().equals(player.getUUID())) {
+                    abortWalking(entry.getKey(), server);
+                    return true;
+                }
+                return false;
+            });
         }
     }
 
@@ -178,6 +201,9 @@ public class ServerEventHandler {
 
             if (doDistanceCheck) {
                 checkConversationDistance(player);
+                if (McTalkingConfig.INSTANCE.instance().enableUrgentContactWalkToPlayer) {
+                    checkUrgentContactAbort(player);
+                }
             }
 
             AbstractEntityCitizen talkingCitizen = ConversationManager.getActiveEntityForPlayer(player.getUUID());
@@ -205,6 +231,11 @@ public class ServerEventHandler {
             if (doContactCheck) {
                 checkForCitizenInitiatedContact(player, citizens, contactedCitizens);
             }
+        }
+
+        // Walking citizens: update once per tick interval, not per player
+        if (doDistanceCheck && McTalkingConfig.INSTANCE.instance().enableUrgentContactWalkToPlayer) {
+            updateWalkingCitizens(server);
         }
 
         // Random citizen-to-citizen conversations (once per interval, not per player)
@@ -332,10 +363,20 @@ public class ServerEventHandler {
                                                    Set<UUID> contactedThisInterval) {
         if (McTalkingConfig.INSTANCE.instance().geminiApiKey.isEmpty()) return;
         double baseChance = McTalkingConfig.INSTANCE.instance().citizenContactBaseChance;
+        boolean walkToPlayer = McTalkingConfig.INSTANCE.instance().enableUrgentContactWalkToPlayer;
 
-        for (AbstractEntityCitizen citizen : citizens) {
+        // When walk-to-player is enabled, scan a wider range for urgent contacts only
+        List<AbstractEntityCitizen> contactCitizens = citizens;
+        if (walkToPlayer) {
+            double wideRange = McTalkingConfig.INSTANCE.instance().urgentContactSearchRange;
+            var wideAabb = player.getBoundingBox().inflate(wideRange);
+            contactCitizens = player.level().getEntitiesOfClass(AbstractEntityCitizen.class, wideAabb);
+        }
+
+        for (AbstractEntityCitizen citizen : contactCitizens) {
             if (!ConversationManager.canCitizenSpeak(citizen)) continue;
             if (citizen.getCitizenData() == null) continue;
+            if (walkingCitizens.containsKey(citizen.getUUID())) continue;
             // Skip citizens that already initiated contact this interval (dedup across players)
             if (!contactedThisInterval.add(citizen.getUUID())) continue;
 
@@ -343,9 +384,16 @@ public class ServerEventHandler {
             if (urgencyWeight <= 0) continue;
 
             if (Math.random() < baseChance * urgencyWeight) {
-                McTalking.LOGGER.info("[CitizenContact] Citizen {} initiating contact with player {}",
-                        citizen.getCitizenData().getName(), player.getName().getString());
-                ConversationManager.startUrgentContact(citizen, player);
+                McTalking.LOGGER.info("[CitizenContact] Citizen {} initiating {} with player {}",
+                        citizen.getCitizenData().getName(),
+                        walkToPlayer ? "walk-to-player" : "contact",
+                        player.getName().getString());
+
+                if (walkToPlayer) {
+                    startWalkingUrgentContact(citizen, player);
+                } else {
+                    ConversationManager.startUrgentContact(citizen, player);
+                }
                 break; // Only one citizen per player per check
             }
         }
@@ -394,7 +442,111 @@ public class ServerEventHandler {
             }
         }
 
+        if (data.getJobStatus() == JobStatus.STUCK) {
+            weight += McTalkingConfig.INSTANCE.instance().blockingTaskUrgencyMultiplier;
+        }
+
         return weight;
+    }
+
+    private void startWalkingUrgentContact(AbstractEntityCitizen citizen, ServerPlayer player) {
+        if (!ConversationManager.claimSlot(citizen, false)) {
+            McTalking.LOGGER.debug("[CitizenContact] No slot available for walking citizen {}", citizen.getUUID());
+            return;
+        }
+
+        walkingCitizens.put(citizen.getUUID(), new WalkingTarget(player.getUUID(), tickCounter));
+        AiStatusHelper.setAiStatusSynced(citizen, AiStatus.URGENT_WALKING);
+
+        citizen.getNavigation().moveTo(player, McTalkingConfig.CITIZEN_URGENT_WALK_SPEED);
+
+        McTalking.LOGGER.info("[CitizenContact] Citizen {} walking to player {}", 
+                citizen.getCitizenData().getName(), player.getName().getString());
+    }
+
+    private void updateWalkingCitizens(MinecraftServer server) {
+        var it = walkingCitizens.entrySet().iterator();
+        while (it.hasNext()) {
+            var entry = it.next();
+            UUID citizenId = entry.getKey();
+            WalkingTarget target = entry.getValue();
+
+            var player = server.getPlayerList().getPlayer(target.playerId());
+            if (player == null || !player.isAlive()) {
+                abortWalking(citizenId, server);
+                it.remove();
+                continue;
+            }
+
+            // Find the citizen entity on the server
+            AbstractEntityCitizen citizen = findWalkingCitizenEntity(server, citizenId);
+            if (citizen == null || !citizen.isAlive()) {
+                abortWalking(citizenId, server);
+                it.remove();
+                continue;
+            }
+
+            // Check if urgent need is resolved
+            if (calculateUrgencyWeight(citizen) <= 0) {
+                McTalking.LOGGER.info("[CitizenContact] Citizen {} — urgent need resolved, aborting walk",
+                        citizen.getCitizenData().getName());
+                citizen.getNavigation().stop();
+                AiStatusHelper.setAiStatusSynced(citizen, AiStatus.NONE);
+                ConversationManager.releaseSlot(citizen);
+                it.remove();
+                continue;
+            }
+
+            // Check if in voice range to start conversation
+            double voiceRange = McTalkingConfig.INSTANCE.instance().mumblingDetectionRange;
+            if (citizen.distanceToSqr(player) <= voiceRange * voiceRange) {
+                McTalking.LOGGER.info("[CitizenContact] Citizen {} reached player, starting urgent contact",
+                        citizen.getCitizenData().getName());
+                it.remove();
+                // Release walking slot so canCitizenSpeak doesn't block the conversation
+                AiStatusHelper.setAiStatusSynced(citizen, AiStatus.NONE);
+                ConversationManager.releaseSlot(citizen);
+                ConversationManager.startUrgentContact(citizen, player);
+                continue;
+            }
+
+            // Repath every 20 ticks
+            if (tickCounter - target.lastRepathTick >= 20) {
+                citizen.getNavigation().moveTo(player, McTalkingConfig.CITIZEN_URGENT_WALK_SPEED);
+                entry.setValue(new WalkingTarget(target.playerId(), tickCounter));
+            }
+        }
+    }
+
+    private void abortWalking(UUID citizenId, MinecraftServer server) {
+        AbstractEntityCitizen entity = findWalkingCitizenEntity(server, citizenId);
+        if (entity != null && entity.isAlive()) {
+            entity.getNavigation().stop();
+            AiStatusHelper.setAiStatusSynced(entity, AiStatus.NONE);
+        }
+        ConversationManager.releaseSlot(citizenId);
+    }
+
+    @Nullable
+    private AbstractEntityCitizen findWalkingCitizenEntity(MinecraftServer server, UUID citizenId) {
+        for (var p : server.getPlayerList().getPlayers()) {
+            var e = p.serverLevel().getEntities().get(citizenId);
+            if (e instanceof AbstractEntityCitizen c) {
+                return c;
+            }
+        }
+        return null;
+    }
+
+    private void checkUrgentContactAbort(ServerPlayer player) {
+        AbstractEntityCitizen citizen = ConversationManager.getActiveEntityForPlayer(player.getUUID());
+        if (citizen == null || citizen.getCitizenData() == null) return;
+
+        if (calculateUrgencyWeight(citizen) <= 0) {
+            McTalking.LOGGER.info("[CitizenContact] Urgent need resolved during conversation for citizen {}",
+                    citizen.getCitizenData().getName());
+            ConversationManager.endConversation(player.getUUID(), false);
+        }
     }
 
     /**

--- a/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
+++ b/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
@@ -67,6 +67,8 @@ import net.minecraftforge.fml.common.Mod;
  * Handler for server-side events related to player-citizen interactions.
  */
 public class ServerEventHandler {
+    private static ServerEventHandler INSTANCE;
+
     private int tickCounter = 0;
 
     private record WalkingTarget(UUID playerId, int lastRepathTick) {}
@@ -74,6 +76,10 @@ public class ServerEventHandler {
 
     /** playerId → System.currentTimeMillis() of the last urgent contact for that player. */
     private final Map<UUID, Long> lastPlayerUrgentContactTimes = new HashMap<>();
+
+    public ServerEventHandler() {
+        INSTANCE = this;
+    }
 
     /**
      * Called when the server starts
@@ -464,6 +470,18 @@ public class ServerEventHandler {
         }
 
         return weight;
+    }
+
+    /**
+     * Triggers the walk-to-player urgent contact flow for a citizen targeting a player.
+     * Used by the debug command {@code /talking_colonists urgent_contact}.
+     */
+    public static void triggerWalkToPlayer(AbstractEntityCitizen citizen, ServerPlayer player) {
+        if (INSTANCE == null) {
+            McTalking.LOGGER.warn("[CitizenContact] ServerEventHandler not initialized");
+            return;
+        }
+        INSTANCE.startWalkingUrgentContact(citizen, player);
     }
 
     private void startWalkingUrgentContact(AbstractEntityCitizen citizen, ServerPlayer player) {

--- a/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
+++ b/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
@@ -151,6 +151,7 @@ public class ServerEventHandler {
                 }
                 return false;
             });
+            lastPlayerUrgentContactTimes.remove(player.getUUID());
         }
     }
 
@@ -502,10 +503,24 @@ public class ServerEventHandler {
                 continue;
             }
 
-            // Check if urgent need is resolved
-            if (calculateUrgencyWeight(citizen) <= 0) {
-                McTalking.LOGGER.info("[CitizenContact] Citizen {} — urgent need resolved, aborting walk",
+            // If the player started a conversation with this citizen (e.g. via Talking Device)
+            // while they were walking, stop walking and let the conversation take over.
+            if (ConversationManager.getPlayerForEntity(citizenId) != null) {
+                McTalking.LOGGER.info("[CitizenContact] Citizen {} picked up for player conversation, aborting walk",
                         citizen.getCitizenData().getName());
+                citizen.getNavigation().stop();
+                AiStatusHelper.setAiStatusSynced(citizen, AiStatus.NONE);
+                // Don't release the slot — the player conversation now holds it.
+                it.remove();
+                continue;
+            }
+
+            // Check if urgent need is resolved
+            var urgencyData = citizen.getCitizenData();
+            if (calculateUrgencyWeight(citizen) <= 0) {
+                String citizenName = urgencyData != null ? urgencyData.getName() : "unknown";
+                McTalking.LOGGER.info("[CitizenContact] Citizen {} — urgent need resolved, aborting walk",
+                        citizenName);
                 citizen.getNavigation().stop();
                 AiStatusHelper.setAiStatusSynced(citizen, AiStatus.NONE);
                 ConversationManager.releaseSlot(citizen);
@@ -514,16 +529,19 @@ public class ServerEventHandler {
             }
 
             // Check if in voice range to start conversation
-            double voiceRange = McTalkingConfig.INSTANCE.instance().mumblingDetectionRange;
-            if (citizen.distanceToSqr(player) <= voiceRange * voiceRange) {
-                McTalking.LOGGER.info("[CitizenContact] Citizen {} reached player, starting urgent contact",
-                        citizen.getCitizenData().getName());
-                it.remove();
-                // Release walking slot so canCitizenSpeak doesn't block the conversation
-                AiStatusHelper.setAiStatusSynced(citizen, AiStatus.NONE);
-                ConversationManager.releaseSlot(citizen);
-                ConversationManager.startUrgentContact(citizen, player);
-                continue;
+            // Must be in the same dimension for distance checks to be meaningful
+            if (citizen.level() == player.level()) {
+                double voiceRange = McTalkingConfig.INSTANCE.instance().mumblingDetectionRange;
+                if (citizen.distanceToSqr(player) <= voiceRange * voiceRange) {
+                    McTalking.LOGGER.info("[CitizenContact] Citizen {} reached player, starting urgent contact",
+                            citizen.getCitizenData().getName());
+                    it.remove();
+                    // Release walking slot so canCitizenSpeak doesn't block the conversation
+                    AiStatusHelper.setAiStatusSynced(citizen, AiStatus.NONE);
+                    ConversationManager.releaseSlot(citizen);
+                    ConversationManager.startUrgentContact(citizen, player);
+                    continue;
+                }
             }
 
             // Repath every 20 ticks

--- a/src/main/java/me/sshcrack/mc_talking/api/prompt/CitizenPromptProvider.java
+++ b/src/main/java/me/sshcrack/mc_talking/api/prompt/CitizenPromptProvider.java
@@ -48,7 +48,7 @@ public interface CitizenPromptProvider {
             case SICK:
                 return "ill and needing care";
             case EAT:
-                return "hungry and looking for food";
+                return "eating at the restaurant";
             case UNKNOWN:
             default:
                 break;

--- a/src/main/java/me/sshcrack/mc_talking/api/prompt/view/CitizenPromptView.java
+++ b/src/main/java/me/sshcrack/mc_talking/api/prompt/view/CitizenPromptView.java
@@ -24,6 +24,9 @@ import java.util.UUID;
  * @param recentColonyEvents Descriptions of recent colony lifecycle events (deaths, births, building changes), or empty list if none
  * @param colonyConnections     Diplomatic connections to neighboring colonies, e.g. "Oakvale (ALLY)", or {@code null} if none
  * @param colonyMilestone Colony milestone description (buildings built, mobs killed, etc.), or {@code null} if none
+ * @param citizenAiState        Current CitizenAI state, e.g. "WORKING", "IDLE", "SLEEP", "EATING" — from {@code /mc citizens info}, or {@code null} if entity not loaded
+ * @param workAiState           Current work AI state, e.g. "IDLE", "START_WORKING", "NEEDS_ITEM" — from {@code /mc citizens info}, or {@code null} if entity not loaded
+ * @param nameTagDescription    Job nametag description, the citizen's current activity text — from {@code /mc citizens info}, or {@code null} if unavailable
  */
 public record CitizenPromptView(
         String name,
@@ -64,6 +67,9 @@ public record CitizenPromptView(
         @Nullable List<String> activeQuests,
         List<String> recentColonyEvents,
         @Nullable List<String> colonyConnections,
-        @Nullable String colonyMilestone
+        @Nullable String colonyMilestone,
+        @Nullable String citizenAiState,
+        @Nullable String workAiState,
+        @Nullable String nameTagDescription
 ) {
 }

--- a/src/main/java/me/sshcrack/mc_talking/commands/DebugUrgentContactCommand.java
+++ b/src/main/java/me/sshcrack/mc_talking/commands/DebugUrgentContactCommand.java
@@ -1,0 +1,52 @@
+package me.sshcrack.mc_talking.commands;
+
+import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import me.sshcrack.mc_talking.ServerEventHandler;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+public class DebugUrgentContactCommand {
+
+    private static final SimpleCommandExceptionType NOT_A_CITIZEN =
+            new SimpleCommandExceptionType(Component.translatable("mc_talking.debug.not_citizen"));
+
+    private static final SimpleCommandExceptionType NOT_A_PLAYER =
+            new SimpleCommandExceptionType(Component.translatable("mc_talking.debug.not_player"));
+
+    private DebugUrgentContactCommand() {
+    }
+
+    public static void addTo(LiteralArgumentBuilder<CommandSourceStack> root) {
+        root.then(Commands.literal("urgent_contact")
+                .then(Commands.argument("citizen", EntityArgument.entity())
+                        .executes(ctx -> execute(ctx.getSource(), EntityArgument.getEntity(ctx, "citizen")))));
+    }
+
+    private static int execute(CommandSourceStack source, net.minecraft.world.entity.Entity target) throws CommandSyntaxException {
+        if (!(target instanceof AbstractEntityCitizen citizen)) {
+            throw NOT_A_CITIZEN.create();
+        }
+
+        var sender = source.getEntity();
+        if (!(sender instanceof ServerPlayer player)) {
+            throw NOT_A_PLAYER.create();
+        }
+
+        ServerEventHandler.triggerWalkToPlayer(citizen, player);
+
+        String citizenName = citizen.getCitizenData() != null
+                ? citizen.getCitizenData().getName()
+                : citizen.getUUID().toString().substring(0, 8);
+
+        source.sendSuccess(() -> Component.translatable("mc_talking.debug.urgent_contact_triggered", citizenName)
+                .withStyle(ChatFormatting.GREEN), false);
+        return 1;
+    }
+}

--- a/src/main/java/me/sshcrack/mc_talking/commands/McTalkingDebugCommand.java
+++ b/src/main/java/me/sshcrack/mc_talking/commands/McTalkingDebugCommand.java
@@ -24,6 +24,7 @@ public class McTalkingDebugCommand {
         DebugCitizenCommand.addTo(root);
         DebugMemoryCommand.addTo(root);
         DebugEventsCommand.addTo(root);
+        DebugUrgentContactCommand.addTo(root);
         ListToolsCommand.addTo(root);
 
         dispatcher.register(root);

--- a/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
+++ b/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
@@ -187,7 +187,7 @@ public class McTalkingConfig {
     @AutoGen(category = "citizens", group = "citizen_contact")
     @DoubleSlider(min = 0.0, max = 1.0, step = 0.01)
     @SerialEntry(comment = "Base chance (0.0-1.0) per check interval that an urgent citizen speaks to a nearby player. Multiplied by an urgency weight derived from the citizen's state (unhappiness, injury, hunger, etc.).")
-    public double citizenContactBaseChance = 0.02;
+    public double citizenContactBaseChance = 0.5;
 
     @AutoGen(category = "citizens", group = "citizen_contact")
     @IntField(min = 1, max = 10000)
@@ -208,6 +208,11 @@ public class McTalkingConfig {
     @DoubleSlider(min = 0.0, max = 10.0, step = 0.1)
     @SerialEntry(comment = "Extra urgency weight applied when the citizen is stuck (blocked by missing tools/items). Makes them much more likely to call for help.")
     public double blockingTaskUrgencyMultiplier = 3.0;
+
+    @AutoGen(category = "citizens", group = "citizen_contact")
+    @IntField(min = 0, max = 10000)
+    @SerialEntry(comment = "Minimum cooldown in seconds between urgent citizen contacts for the same player. Set to 0 to disable.")
+    public int playerUrgentContactCooldownSeconds = 60;
 
     @AutoGen(category = "citizens", group = "voice_chat")
     @TickBox
@@ -238,7 +243,7 @@ public class McTalkingConfig {
     public int colonyEventWindowSeconds = 1200;
 
     @SerialEntry(comment = "Internal: config schema version for one-time migrations.")
-    public int configVersion = 0;
+    public int configVersion = 2;
 
     // Personality Archetypes
     @AutoGen(category = "citizens", group = "personality")
@@ -363,6 +368,16 @@ public class McTalkingConfig {
                 McTalking.LOGGER.info("[Config] Migrated conversationMode from LIVE_WEBSOCKETS to AUTO");
             }
             INSTANCE.instance().configVersion = 1;
+            INSTANCE.save();
+        }
+
+        // One-time migration: old default citizenContactBaseChance (0.02) → new default (0.5)
+        if (INSTANCE.instance().configVersion < 2) {
+            if (INSTANCE.instance().citizenContactBaseChance <= 0.02) {
+                INSTANCE.instance().citizenContactBaseChance = 0.5;
+                McTalking.LOGGER.info("[Config] Migrated citizenContactBaseChance from 0.02 to 0.5");
+            }
+            INSTANCE.instance().configVersion = 2;
             INSTANCE.save();
         }
     }

--- a/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
+++ b/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
@@ -31,6 +31,9 @@ public class McTalkingConfig {
     public static final String FLASH_MODEL = "gemini-flash-lite-latest";
     public static final String TTS_MODEL = "gemini-3.1-flash-tts-preview";
 
+    /** Movement speed multiplier when a citizen walks to the player on urgent contact. */
+    public static final double CITIZEN_URGENT_WALK_SPEED = 1.2;
+
     public static final ConfigClassHandler<McTalkingConfig> INSTANCE = ConfigClassHandler.createBuilder(McTalkingConfig.class)
             .id(YACLPlatform.rl("mc_talking", "config"))
             .serializer(config -> GsonConfigSerializerBuilder.create(config)
@@ -190,6 +193,21 @@ public class McTalkingConfig {
     @IntField(min = 1, max = 10000)
     @SerialEntry(comment = "How often (in server ticks) to check for citizens that should initiate contact. 20 ticks = 1 second")
     public int citizenContactCheckIntervalTicks = 400;
+
+    @AutoGen(category = "citizens", group = "citizen_contact")
+    @TickBox
+    @SerialEntry(comment = "When enabled, urgent citizens walk to the player and follow them, searching over a larger radius. The conversation auto-starts when they get close.")
+    public boolean enableUrgentContactWalkToPlayer = true;
+
+    @AutoGen(category = "citizens", group = "citizen_contact")
+    @DoubleField(min = 5.0, max = 100.0)
+    @SerialEntry(comment = "Search radius for urgent contacts when walk-to-player is enabled.")
+    public double urgentContactSearchRange = 30.0;
+
+    @AutoGen(category = "citizens", group = "citizen_contact")
+    @DoubleSlider(min = 0.0, max = 10.0, step = 0.1)
+    @SerialEntry(comment = "Extra urgency weight applied when the citizen is stuck (blocked by missing tools/items). Makes them much more likely to call for help.")
+    public double blockingTaskUrgencyMultiplier = 3.0;
 
     @AutoGen(category = "citizens", group = "voice_chat")
     @TickBox

--- a/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
+++ b/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
@@ -78,7 +78,7 @@ public class McTalkingConfig {
 
     @AutoGen(category = "general", group = "interaction")
     @TickBox
-    @SerialEntry(comment = "If true, citizens continue wandering normally while in a player conversation. "
+    @SerialEntry(comment = "If true, citizens continue wandering normally while in a player conversation / conversation with another citizen etc. "
             + "If false (default), they stay in place for the duration of the conversation.")
     public boolean continueWorkDuringConversation = false;
 

--- a/src/main/java/me/sshcrack/mc_talking/item/CitizenTalkingDevice.java
+++ b/src/main/java/me/sshcrack/mc_talking/item/CitizenTalkingDevice.java
@@ -3,6 +3,8 @@ package me.sshcrack.mc_talking.item;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.core.entity.visitor.VisitorCitizen;
 import me.sshcrack.mc_talking.ConversationManager;
+import me.sshcrack.mc_talking.McTalkingVoicechatPlugin;
+import me.sshcrack.mc_talking.config.ModalityModes;
 import net.minecraft.ChatFormatting;
 /*? if forge {*/
 /*import net.minecraft.nbt.CompoundTag;
@@ -182,6 +184,15 @@ public class CitizenTalkingDevice extends Item {
                             .withStyle(ChatFormatting.RED)
             );
             return true; // Still prevent attack
+        }
+
+        if (McTalkingVoicechatPlugin.shouldDisableColoniesTicks(serverPlayer)) {
+            serverPlayer.sendSystemMessage(
+                    Component.literal("Your voice chat is currently disabled. Please enable it to talk to citizens.")
+                            .withStyle(ChatFormatting.RED)
+            );
+
+            return true;
         }
 
         // If there was a previously focused entity, remove its glowing effect

--- a/src/main/java/me/sshcrack/mc_talking/item/CitizenTalkingDevice.java
+++ b/src/main/java/me/sshcrack/mc_talking/item/CitizenTalkingDevice.java
@@ -4,7 +4,6 @@ import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.core.entity.visitor.VisitorCitizen;
 import me.sshcrack.mc_talking.ConversationManager;
 import me.sshcrack.mc_talking.McTalkingVoicechatPlugin;
-import me.sshcrack.mc_talking.config.ModalityModes;
 import net.minecraft.ChatFormatting;
 /*? if forge {*/
 /*import net.minecraft.nbt.CompoundTag;

--- a/src/main/java/me/sshcrack/mc_talking/manager/CitizenPromptViewFactory.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/CitizenPromptViewFactory.java
@@ -107,6 +107,9 @@ public final class CitizenPromptViewFactory {
         boolean isGuard = data.getJob() != null && data.getJob().isGuard();
         List<String> colonyConnections = extractColonyConnections(data);
         List<String> recentEvents = extractRecentEvents(data);
+        String citizenAiState = extractCitizenAiState(data);
+        String workAiState = extractWorkAiState(data);
+        String nameTagDescription = extractNameTagDescription(data);
 
         return new CitizenPromptView(
                 data.getName(),
@@ -147,7 +150,10 @@ public final class CitizenPromptViewFactory {
                 activeQuests,
                 recentEvents,
                 colonyConnections,
-                colonyMilestone
+                colonyMilestone,
+                citizenAiState,
+                workAiState,
+                nameTagDescription
         );
     }
 
@@ -159,6 +165,39 @@ public final class CitizenPromptViewFactory {
             return null;
         }
         return Component.translatable(data.getJob().getJobRegistryEntry().getTranslationKey()).getString();
+    }
+
+    @Nullable
+    private static String extractCitizenAiState(ICitizenData data) {
+        var entityOpt = data.getEntity();
+        if (entityOpt.isEmpty()) return null;
+        var entity = entityOpt.get();
+        if (!(entity instanceof com.minecolonies.core.entity.citizen.EntityCitizen citizen)) return null;
+        var ai = citizen.getCitizenAI();
+        if (ai == null) return null;
+        var state = ai.getState();
+        return state != null ? state.toString() : null;
+    }
+
+    @Nullable
+    private static String extractWorkAiState(ICitizenData data) {
+        var entityOpt = data.getEntity();
+        if (entityOpt.isEmpty()) return null;
+        var entity = entityOpt.get();
+        var jobHandler = entity.getCitizenJobHandler();
+        if (jobHandler == null) return null;
+        var workAi = jobHandler.getWorkAI();
+        if (workAi == null) return null;
+        var stateAi = workAi.getStateAI();
+        if (stateAi == null) return null;
+        var state = stateAi.getState();
+        return state != null ? state.toString() : null;
+    }
+
+    @Nullable
+    private static String extractNameTagDescription(ICitizenData data) {
+        if (data.getJob() == null) return null;
+        return data.getJob().getNameTagDescription();
     }
 
     private static List<String> extractParents(ICitizenData data) {

--- a/src/main/java/me/sshcrack/mc_talking/manager/DefaultCitizenPromptProvider.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/DefaultCitizenPromptProvider.java
@@ -208,6 +208,17 @@ public class DefaultCitizenPromptProvider implements CitizenPromptProvider {
             }
         }
 
+        String citizenAiState = view.citizenAiState();
+        String workAiState = view.workAiState();
+        String nameTagDescription = view.nameTagDescription();
+        if (citizenAiState != null || workAiState != null || nameTagDescription != null) {
+            prompt.append("- AI state: ");
+            if (citizenAiState != null) prompt.append(citizenAiState);
+            if (workAiState != null) prompt.append(" / ").append(workAiState);
+            if (nameTagDescription != null) prompt.append(" — ").append(nameTagDescription);
+            prompt.append("\n");
+        }
+
         if (view.environment() != null) {
             prompt.append("- ").append(view.environment()).append("\n");
         }

--- a/src/main/java/me/sshcrack/mc_talking/manager/GeminiWsClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/GeminiWsClient.java
@@ -144,6 +144,18 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
         onCloseActions.add(action);
     }
 
+    private void fireOnCloseActions() {
+        synchronized (onCloseActions) {
+            for (Runnable action : onCloseActions) {
+                try {
+                    action.run();
+                } catch (Exception e) {
+                    McTalking.LOGGER.error("Error executing onClose action", e);
+                }
+            }
+        }
+    }
+
     public void endConversationWhenPossible() {
         this.shouldEndConversation = true;
     }
@@ -594,7 +606,11 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
 
     @Override
     public void onClose(int code, String reason, boolean remote) {
-        super.onClose(code, reason, remote);
+        try {
+            super.onClose(code, reason, remote);
+        } catch (Exception e) {
+            McTalking.LOGGER.error("Error in GeminiLiveClient.onClose", e);
+        }
 
         if (intentionalClose) {
             setWsSessionState(WsSessionState.CLOSED, "intentional close");
@@ -605,7 +621,7 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
             return;
         }
 
-        if (reason.contains("BidiGenerateContent session")) {
+        if (reason != null && reason.contains("BidiGenerateContent session")) {
             var mem = ((CitizenDataMemoryExtended) entity.getCitizenData()).mc_talking$getOrInitializeMemory();
             mem.setSessionToken("");
             ensureConnectionForQueuedInput("session token invalidated");
@@ -615,13 +631,17 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
         if (code == 1000) {
             setWsSessionState(WsSessionState.CLOSED, "normal close");
             McTalking.LOGGER.info("GeminiWsClient closed normally: {}", reason);
+            fireOnCloseActions();
         } else if (code == 1001) {
             setWsSessionState(WsSessionState.CLOSED, "going away");
             McTalking.LOGGER.info("GeminiWsClient closed (going away): {}", reason);
+            fireOnCloseActions();
         } else {
             McTalking.LOGGER.warn("GeminiWsClient closed: {} and code {}", reason, code);
             if (unrecognizedCloseRetryCount >= MAX_UNRECOGNIZED_CLOSE_RETRIES) {
                 setWsSessionState(WsSessionState.TERMINAL_ERROR, "retry cap exceeded for close code " + code);
+                fireOnCloseActions();
+                AiStatusHelper.setAiStatusSynced(getEntity(), AiStatus.NONE);
                 onErrorEvent(new RuntimeException("Close with code " + code + ": " + reason));
                 return;
             }
@@ -629,7 +649,14 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
             unrecognizedCloseRetryCount++;
             McTalking.LOGGER.warn("Attempting reconnect after unrecognized close code {} (attempt {}/{})",
                     code, unrecognizedCloseRetryCount, MAX_UNRECOGNIZED_CLOSE_RETRIES);
-            ensureConnectionForQueuedInput("abnormal close code " + code + " attempt " + unrecognizedCloseRetryCount);
+            try {
+                ensureConnectionForQueuedInput("abnormal close code " + code + " attempt " + unrecognizedCloseRetryCount);
+            } catch (Exception e) {
+                McTalking.LOGGER.error("Reconnect failed after close code {}", code, e);
+                setWsSessionState(WsSessionState.TERMINAL_ERROR, "reconnect failed");
+                fireOnCloseActions();
+                AiStatusHelper.setAiStatusSynced(getEntity(), AiStatus.NONE);
+            }
         }
     }
 
@@ -648,6 +675,8 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
         }
 
         setWsSessionState(WsSessionState.TERMINAL_ERROR, "websocket error");
+        fireOnCloseActions();
+        AiStatusHelper.setAiStatusSynced(getEntity(), AiStatus.NONE);
         onErrorEvent(ex);
     }
 
@@ -730,15 +759,7 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
         super.close();
         stream.close();
 
-        synchronized (onCloseActions) {
-            for (Runnable action : onCloseActions) {
-                try {
-                    action.run();
-                } catch (Exception e) {
-                    McTalking.LOGGER.error("Error executing onClose action", e);
-                }
-            }
-        }
+        fireOnCloseActions();
     }
 
     /**

--- a/src/main/java/me/sshcrack/mc_talking/mixin/CitizenAIMixin.java
+++ b/src/main/java/me/sshcrack/mc_talking/mixin/CitizenAIMixin.java
@@ -1,6 +1,8 @@
 package me.sshcrack.mc_talking.mixin;
 
-import com.minecolonies.core.entity.ai.minimal.EntityAICitizenWander;
+import com.minecolonies.api.entity.ai.statemachine.states.CitizenAIState;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.core.entity.ai.workers.CitizenAI;
 import com.minecolonies.core.entity.citizen.EntityCitizen;
 import me.sshcrack.mc_talking.ConversationManager;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
@@ -11,18 +13,18 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(value = EntityAICitizenWander.class, remap = false)
-public class EntityAICitizenWanderMixin {
+@Mixin(value = CitizenAI.class, remap = false)
+public class CitizenAIMixin {
 
     @Shadow
     @Final
-    protected EntityCitizen citizen;
+    private EntityCitizen citizen;
 
-    @Inject(method = "canUse", at = @At("HEAD"), cancellable = true)
-    private void mc_talking$suppressWanderingDuringConversation(CallbackInfoReturnable<Boolean> cir) {
+    @Inject(method = "calculateNextState", at = @At("HEAD"), cancellable = true)
+    private void mc_talking$suppressWorkDuringUrgentContact(CallbackInfoReturnable<IState> cir) {
         if (McTalkingConfig.INSTANCE.instance().continueWorkDuringConversation) return;
         if (ConversationManager.isCitizenBusy(citizen)) {
-            cir.setReturnValue(false);
+            cir.setReturnValue(CitizenAIState.IDLE);
         }
     }
 }

--- a/src/main/java/me/sshcrack/mc_talking/network/AiStatus.java
+++ b/src/main/java/me/sshcrack/mc_talking/network/AiStatus.java
@@ -15,7 +15,8 @@ public enum AiStatus {
     IN_CONVERSATION,
     LISTENING,
     NONE,
-    RECONNECTING;
+    RECONNECTING,
+    URGENT_WALKING;
 
     public static AiStatus fromId(int id) {
         if (id < 0 || id >= values().length) {

--- a/src/main/java/me/sshcrack/mc_talking/util/MumblingTopicHelper.java
+++ b/src/main/java/me/sshcrack/mc_talking/util/MumblingTopicHelper.java
@@ -611,6 +611,7 @@ public final class MumblingTopicHelper {
     /**
      * Queries the citizen's work building for open requests and returns a comma-separated
      * list of the items/equipment they are waiting for. Returns empty string if nothing found.
+     * Limited to the first 5 items to keep the prompt bounded.
      */
     private static String collectNeededItems(ICitizenData data) {
         IBuilding workBuilding = data.getWorkBuilding();
@@ -621,6 +622,10 @@ public final class MumblingTopicHelper {
 
         List<String> items = new ArrayList<>();
         for (IRequest<?> req : openRequests) {
+            if (items.size() >= 5) {
+                items.add("...and more");
+                break;
+            }
             String display = req.getShortDisplayString().getString();
             if (display != null && !display.isEmpty()) {
                 items.add(display);

--- a/src/main/java/me/sshcrack/mc_talking/util/MumblingTopicHelper.java
+++ b/src/main/java/me/sshcrack/mc_talking/util/MumblingTopicHelper.java
@@ -1,13 +1,19 @@
 package me.sshcrack.mc_talking.util;
 
 import com.minecolonies.api.colony.ICitizenData;
+import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.jobs.ModJobs;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
+import com.minecolonies.api.colony.requestsystem.request.IRequest;
+import com.minecolonies.api.entity.ai.JobStatus;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.citizen.VisibleCitizenStatus;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.Difficulty;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 public final class MumblingTopicHelper {
@@ -527,6 +533,26 @@ public final class MumblingTopicHelper {
 
         var data = citizen.getCitizenData();
 
+        // ── CRITICAL: blocking task (STUCK) ──────────────
+        if (data.getJobStatus() == JobStatus.STUCK) {
+            String jobName = data.getJob() != null
+                    ? Component.translatable(data.getJob().getJobRegistryEntry().getTranslationKey()).getString()
+                    : "worker";
+            String needed = collectNeededItems(data);
+            if (!needed.isEmpty()) {
+                return format(playerName, pick(
+                        "You're completely stuck and can't do your work as a " + jobName + ". You need: " + needed + ". Call out to %s by name and urgently explain you're blocked and need help.",
+                        "You can't continue your job as a " + jobName + " because you're missing something important: " + needed + ". Call out to %s by name and ask for assistance.",
+                        "As a " + jobName + ", you're stuck waiting for supplies: " + needed + ". Call out to %s by name and plead for help to get back to work."
+                ));
+            } else {
+                return format(playerName, pick(
+                        "You're completely stuck and can't do your work as a " + jobName + ". Call out to %s by name and urgently explain what's wrong and ask for help.",
+                        "You can't continue your job as a " + jobName + " because you're blocked by missing supplies. Call out to %s by name and ask for assistance."
+                ));
+            }
+        }
+
         // ── CRITICAL: sickness ───────────────────────────
         if (data.getCitizenDiseaseHandler().isSick()) {
             return format(playerName, pick(
@@ -580,6 +606,29 @@ public final class MumblingTopicHelper {
         }
 
         return buildGenericUrgentPrompt(playerName);
+    }
+
+    /**
+     * Queries the citizen's work building for open requests and returns a comma-separated
+     * list of the items/equipment they are waiting for. Returns empty string if nothing found.
+     */
+    private static String collectNeededItems(ICitizenData data) {
+        IBuilding workBuilding = data.getWorkBuilding();
+        if (workBuilding == null) return "";
+
+        Collection<IRequest<?>> openRequests = workBuilding.getOpenRequests(data.getId());
+        if (openRequests == null || openRequests.isEmpty()) return "";
+
+        List<String> items = new ArrayList<>();
+        for (IRequest<?> req : openRequests) {
+            String display = req.getShortDisplayString().getString();
+            if (display != null && !display.isEmpty()) {
+                items.add(display);
+            }
+        }
+
+        if (items.isEmpty()) return "";
+        return String.join(", ", items);
     }
 
     private static String format(String playerName, String template) {

--- a/src/main/resources/assets/mc_talking/lang/en_us.json
+++ b/src/main/resources/assets/mc_talking/lang/en_us.json
@@ -56,6 +56,8 @@
   "mc_talking.commands.list_tools": "List of available tools:\n%s",
 
   "mc_talking.debug.not_citizen": "Target must be a MineColonies citizen.",
+  "mc_talking.debug.not_player": "Command must be executed by a player.",
+  "mc_talking.debug.urgent_contact_triggered": "Triggered urgent contact walk-to-player for %s",
   "mc_talking.debug.no_citizen_data": "Citizen has no data (offline/unloaded).",
   "mc_talking.debug.no_connections": "No active Gemini connections.",
   "mc_talking.debug.no_colony_specified": "Specify a colony ID or execute near a colony.",

--- a/src/main/resources/assets/mc_talking/lang/en_us.json
+++ b/src/main/resources/assets/mc_talking/lang/en_us.json
@@ -98,6 +98,17 @@
   "yacl3.config.mc_talking:config.category.citizens.group.mumbling": "Mumbling",
   "yacl3.config.mc_talking:config.category.citizens.group.citizen_contact": "Citizen-Initiated Contact",
 
+  "yacl3.config.mc_talking:config.category.citizens.group.colony_events": "Colony Events",
+  "yacl3.config.mc_talking:config.colonyEventWindowSeconds": "Colony Event Window (seconds)",
+  "yacl3.config.mc_talking:config.colonyEventWindowSeconds.desc": "How long (in seconds) colony lifecycle events (births, deaths, job changes, building changes) appear in citizen prompts. Set to 0 to disable.",
+
+  "yacl3.config.mc_talking:config.category.citizens.group.colony_diplomacy": "Colony Diplomacy",
+  "yacl3.config.mc_talking:config.enableColonyDiplomacy": "Enable Colony Diplomacy",
+  "yacl3.config.mc_talking:config.enableColonyDiplomacy.desc": "If enabled, citizens reference neighboring colonies and their diplomatic standing (allies, enemies, etc.) in conversations.",
+
+  "yacl3.config.mc_talking:config.enableColonyStatsMentions": "Enable Colony Stats Mentions",
+  "yacl3.config.mc_talking:config.enableColonyStatsMentions.desc": "If enabled, citizens occasionally mention colony milestones (buildings built, mobs killed, etc.) in their idle mumbles and conversations.",
+
   "yacl3.config.mc_talking:config.geminiApiKey": "API Key",
   "yacl3.config.mc_talking:config.geminiApiKey.desc": "Gemini API key used to authenticate all AI requests. If empty, all functionality is disabled.",
   "yacl3.config.mc_talking:config.currentAiModel": "AI Model",

--- a/src/main/resources/assets/mc_talking/lang/en_us.json
+++ b/src/main/resources/assets/mc_talking/lang/en_us.json
@@ -166,6 +166,10 @@
 
   "yacl3.config.mc_talking:config.blockingTaskUrgencyMultiplier": "Blocking Task Urgency Multiplier",
   "yacl3.config.mc_talking:config.blockingTaskUrgencyMultiplier.desc": "Extra urgency weight for citizens stuck on a task (missing tools/items). Higher values make them much more likely to call for help.",
+
+  "yacl3.config.mc_talking:config.playerUrgentContactCooldownSeconds": "Player Urgent Contact Cooldown (seconds)",
+  "yacl3.config.mc_talking:config.playerUrgentContactCooldownSeconds.desc": "Minimum time between urgent citizen contacts for the same player, preventing multiple citizens from calling out at once. Set to 0 to disable.",
+
   "yacl3.config.mc_talking:config.citizenCooldownSeconds": "Citizen Cooldown (seconds)",
   "yacl3.config.mc_talking:config.citizenCooldownSeconds.desc": "Cooldown after an automatic session ends before that citizen can be auto-selected again (mumbling, urgent contact, or citizen-to-citizen). Set to 0 to disable.",
 

--- a/src/main/resources/assets/mc_talking/lang/en_us.json
+++ b/src/main/resources/assets/mc_talking/lang/en_us.json
@@ -44,6 +44,7 @@
   "mc_talking.ai_status.in_conversation": "In conversation",
   "mc_talking.ai_status.error": "Error",
   "mc_talking.ai_status.reconnecting": "Reconnecting",
+  "mc_talking.ai_status.urgent_walking": "Walking to Player",
   "mc_talking.no_key": "No Gemini API key set. Please set one in the config file of MineColonies Talking. Until then, the mod will not work.",
   "mc_talking.recruit_lore": "Maybe this little gift will help you get this citizen back to join your colony.",
   "mc_talking.invalid_on_visitor": "You cannot use the Talking Device on visitors.",
@@ -145,6 +146,15 @@
   "yacl3.config.mc_talking:config.citizenContactBaseChance.desc": "Base per-check chance for urgent contact. Multiplied by an urgency score from happiness, sickness, hunger, health, and homelessness.",
   "yacl3.config.mc_talking:config.citizenContactCheckIntervalTicks": "Citizen Contact Check Interval (ticks)",
   "yacl3.config.mc_talking:config.citizenContactCheckIntervalTicks.desc": "How often the server checks whether urgent citizens should initiate contact. 20 ticks = 1 second.",
+
+  "yacl3.config.mc_talking:config.enableUrgentContactWalkToPlayer": "Walk to Player on Urgent Contact",
+  "yacl3.config.mc_talking:config.enableUrgentContactWalkToPlayer.desc": "When enabled, urgent citizens walk toward you over a larger search range, follow you until close, then auto-start the conversation. They stop following when the need resolves.",
+
+  "yacl3.config.mc_talking:config.urgentContactSearchRange": "Urgent Contact Search Range",
+  "yacl3.config.mc_talking:config.urgentContactSearchRange.desc": "Extended scan radius (in blocks) for finding citizens with urgent needs when walk-to-player is enabled.",
+
+  "yacl3.config.mc_talking:config.blockingTaskUrgencyMultiplier": "Blocking Task Urgency Multiplier",
+  "yacl3.config.mc_talking:config.blockingTaskUrgencyMultiplier.desc": "Extra urgency weight for citizens stuck on a task (missing tools/items). Higher values make them much more likely to call for help.",
   "yacl3.config.mc_talking:config.citizenCooldownSeconds": "Citizen Cooldown (seconds)",
   "yacl3.config.mc_talking:config.citizenCooldownSeconds.desc": "Cooldown after an automatic session ends before that citizen can be auto-selected again (mumbling, urgent contact, or citizen-to-citizen). Set to 0 to disable.",
 

--- a/src/main/resources/mc_talking.mixins.json
+++ b/src/main/resources/mc_talking.mixins.json
@@ -7,6 +7,7 @@
     "AbstractAISkeletonAccessor",
     "AbstractEntityAIGuardMixin",
     "AbstractEntityCitizenMixin",
+    "CitizenAIMixin",
     "CitizenDataAccessor",
     "CitizenDataMixin",
     "EntityAICitizenWanderMixin",


### PR DESCRIPTION
## Problem
Citizens blocked by tasks (e.g., need a pickaxe) stand at their job building, only initiating urgent contact if the player is very nearby. The player can just walk away.

## Solution
Adds **walk-to-player behavior** for all urgent contacts when the config toggle is enabled:

### New Config Options (all enabled by default)
- `enableUrgentContactWalkToPlayer` (bool, default: `true`) — master toggle
- `urgentContactSearchRange` (double, default: `30.0`) — extended search radius when walk-to-player is on
- `blockingTaskUrgencyMultiplier` (double, default: `3.0`) — extra urgency weight for STUCK citizens

### Changes
1. **Blocking task detection**: `getJobStatus() == STUCK` gets the highest urgency multiplier
2. **Item extraction**: For STUCK citizens, queries the work building's open requests and extracts item names (via `getShortDisplayString()`) to build a specific prompt
3. **Walking/following**: When `enableUrgentContactWalkToPlayer` is on, citizens claim a slot, set navigation toward the player, and repath every 20 ticks
4. **Auto-conversation**: When the citizen reaches `mumblingDetectionRange`, the urgent contact WebSocket session starts automatically
5. **Abort**: When all urgent needs resolve (either while walking or during conversation), the walk/conversation is aborted cleanly
6. **`AiStatus.URGENT_WALKING`** — new status enum for debug display

### Files Changed
- `ServerEventHandler.java` — core walking/following/abort logic
- `McTalkingConfig.java` — 3 new config fields + `CITIZEN_URGENT_WALK_SPEED` constant
- `AiStatus.java` — new `URGENT_WALKING` value
- `MumblingTopicHelper.java` — STUCK prompt with item names from open requests
- `ConversationManager.java` — UUID-based `releaseSlot` overload
- `en_us.json` — translations for new config + status

Closes #62