### PR TITLE
fix: guards should not be treated as homeless

### DIFF
--- a/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
+++ b/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
@@ -373,7 +373,7 @@ public class ServerEventHandler {
             weight += 0.8;
         }
 
-        if (data.getHomeBuilding() == null) {
+        if (data.getHomeBuilding() == null && !CitizenHelper.isCitizenGuard(citizen)) {
             weight += 0.7;
         }
 

--- a/src/main/java/me/sshcrack/mc_talking/manager/CitizenPromptViewFactory.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/CitizenPromptViewFactory.java
@@ -115,7 +115,7 @@ public final class CitizenPromptViewFactory {
                 jobName,
                 isGuard,
                 data.getCitizenDiseaseHandler().isSick(),
-                data.getHomeBuilding() == null,
+                data.getHomeBuilding() == null && !isGuard,
                 parents,
                 data.getPartner() != null,
                 childrenNames,

--- a/src/main/java/me/sshcrack/mc_talking/manager/DefaultCitizenPromptProvider.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/DefaultCitizenPromptProvider.java
@@ -56,6 +56,10 @@ public class DefaultCitizenPromptProvider implements CitizenPromptProvider {
         if (view.homeBuildingDisplayName() != null && !view.homeless()) {
             prompt.append(" | Home: ").append(view.homeBuildingDisplayName())
                     .append(" (level ").append(view.homeBuildingLevel()).append(")");
+        } else if (view.guard() && view.workBuildingDisplayName() != null) {
+            prompt.append(" | Home: ").append(view.workBuildingDisplayName())
+                    .append(" (level ").append(view.workBuildingLevel())
+                    .append(") — your guard post serves as your living quarters");
         }
         prompt.append("\n\n");
         return prompt.toString();
@@ -405,7 +409,7 @@ public class DefaultCitizenPromptProvider implements CitizenPromptProvider {
             if (factor < 0.8 || factor > 1.2) {
                 switch (modifierType) {
                     case HOMELESSNESS:
-                        if (factor < 0.8) {
+                        if (factor < 0.8 && !view.guard()) {
                             prompt.append("- Distressed about housing situation\n");
                         }
                         break;

--- a/src/main/java/me/sshcrack/mc_talking/util/MumblingTopicHelper.java
+++ b/src/main/java/me/sshcrack/mc_talking/util/MumblingTopicHelper.java
@@ -547,7 +547,7 @@ public final class MumblingTopicHelper {
         }
 
         // ── CRITICAL: no home ────────────────────────────
-        if (data.getHomeBuilding() == null) {
+        if (data.getHomeBuilding() == null && !CitizenHelper.isCitizenGuard(citizen)) {
             return format(playerName, pick(
                     "You have nowhere to sleep. Call out to %s by name and urgently ask for help.",
                     "You're distressed about having no home. Call out to %s by name and plead for shelter.",


### PR DESCRIPTION
## Summary

In MineColonies, guard jobs (knights, archers) do not need housing — they live at their guard post. This mod was treating all citizens with `getHomeBuilding() == null` as homeless, causing guards to complain in system prompts and trigger homelessness-themed urgent contact.

## Changes

- **CitizenPromptViewFactory**: Don't mark guards as homeless
- **DefaultCitizenPromptProvider**: Show guard's work building as their residence in the system prompt; skip HOMELESSNESS happiness modifier for guards
- **MumblingTopicHelper**: Skip homelessness urgent contact for guards
- **ServerEventHandler**: Skip homelessness urgency weight for guards

Closes #64