### PR TITLE
fix: suppress SECURITY prompt about missing guards on peaceful difficulty

### DIFF
--- a/src/main/java/me/sshcrack/mc_talking/manager/DefaultCitizenPromptProvider.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/DefaultCitizenPromptProvider.java
@@ -449,7 +449,9 @@ public class DefaultCitizenPromptProvider implements CitizenPromptProvider {
                         break;
                     case SECURITY:
                         if (factor < 0.8) {
-                            prompt.append("- Feels unsafe in the colony\n");
+                            if (!view.peaceful()) {
+                                prompt.append("- Feels unsafe in the colony\n");
+                            }
                         } else {
                             prompt.append("- Feels very secure in the colony\n");
                         }


### PR DESCRIPTION
## Summary
On peaceful difficulty, citizens would complain "Feels unsafe in the colony" when the colony lacked guards — despite there being no monsters or raids. This is misleading.

## Changes
- `DefaultCitizenPromptProvider.java`: Gate the "Feels unsafe" SECURITY happiness modifier output behind `!view.peaceful()`
- On peaceful: the negative branch is silently skipped
- On non-peaceful: behavior is unchanged
- The positive "Feels very secure" branch is always shown regardless

## Why this is safe
- Post-raid trauma, RAIDED status display, and raid stats are *already* gated by `!view.peaceful()` in the same file
- The GUARD DUTY section for guard citizens remains (it describes their identity, not a complaint)
- The positive "Feels very secure" output is harmless and factually correct on peaceful

Closes #66