### PR TITLE
Fix multiplayer player-name confusion in citizen AI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,4 +44,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
+          gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file comment.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,15 @@ jobs:
           path: build-artifacts
 
       - name: Generate PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          artifact_id=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts --jq '.artifacts[] | select(.name=="build-artifacts") | .id' | head -n1)
+          artifact_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts"
+          if [ -n "$artifact_id" ]; then
+            artifact_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/$artifact_id"
+          fi
+
           echo "## Build Artifacts" > comment.md
           echo "" >> comment.md
           echo "These JARs were built from this PR:" >> comment.md
@@ -34,7 +42,7 @@ jobs:
           find build-artifacts -name "*.jar" ! -name "*-sources.jar" ! -name "*-javadoc.jar" -type f | sort | while read jar; do
             name=$(basename "$jar")
             size=$(du -h "$jar" | cut -f1)
-            echo "| \`$name\` | $size |" >> comment.md
+            echo "| [\`$name\`]($artifact_url) | $size |" >> comment.md
           done
           echo "" >> comment.md
           echo "Download from the [GitHub Actions run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)." >> comment.md

--- a/src/main/java/me/sshcrack/mc_talking/McTalkingVoicechatPlugin.java
+++ b/src/main/java/me/sshcrack/mc_talking/McTalkingVoicechatPlugin.java
@@ -147,6 +147,9 @@ public class McTalkingVoicechatPlugin implements VoicechatPlugin {
 
         UUID entityId = entity.getUUID();
 
+        McTalking.LOGGER.info("[Voicechat] Player '{}' ({}) sending audio to entity {} (manager={})",
+                player.getName().getString(), player.getUUID(), entityId, manager.getClass().getSimpleName());
+
         // Process the voice packet
         byte[] opusData = packet.getOpusEncodedData();
         boolean hasVoiceActivity = hasVoiceActivity(opusData);

--- a/src/main/java/me/sshcrack/mc_talking/McTalkingVoicechatPlugin.java
+++ b/src/main/java/me/sshcrack/mc_talking/McTalkingVoicechatPlugin.java
@@ -147,9 +147,6 @@ public class McTalkingVoicechatPlugin implements VoicechatPlugin {
 
         UUID entityId = entity.getUUID();
 
-        McTalking.LOGGER.info("[Voicechat] Player '{}' ({}) sending audio to entity {} (manager={})",
-                player.getName().getString(), player.getUUID(), entityId, manager.getClass().getSimpleName());
-
         // Process the voice packet
         byte[] opusData = packet.getOpusEncodedData();
         boolean hasVoiceActivity = hasVoiceActivity(opusData);

--- a/src/main/java/me/sshcrack/mc_talking/McTalkingVoicechatPlugin.java
+++ b/src/main/java/me/sshcrack/mc_talking/McTalkingVoicechatPlugin.java
@@ -12,6 +12,7 @@ import de.maxhenkel.voicechat.api.events.VoicechatServerStoppedEvent;
 import me.sshcrack.mc_talking.config.ModalityModes;
 import me.sshcrack.mc_talking.conversations.memory.CitizenMemoryGenerator;
 import me.sshcrack.mc_talking.conversations.memory.PlayerConversationMemoryGenerator;
+import me.sshcrack.mc_talking.manager.CitizenWsClient;
 import me.sshcrack.mc_talking.manager.GeminiWsClient;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.LivingEntity;
@@ -150,6 +151,11 @@ public class McTalkingVoicechatPlugin implements VoicechatPlugin {
         byte[] opusData = packet.getOpusEncodedData();
         boolean hasVoiceActivity = hasVoiceActivity(opusData);
         long currentTime = System.currentTimeMillis();
+
+        // Announce the speaker so the AI knows whose voice this is
+        if (manager instanceof CitizenWsClient cws) {
+            cws.announcePlayerIfChanged(player);
+        }
 
         // Forward the voice data to the AI regardless of silence detection
         manager.promptAudioOpus(opusData);

--- a/src/main/java/me/sshcrack/mc_talking/manager/CitizenWsClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/CitizenWsClient.java
@@ -53,6 +53,12 @@ public class CitizenWsClient extends GeminiWsClient {
     private boolean playerInputStarted = false;
 
     /**
+     * The player whose name was most recently announced to the AI.
+     * Used to avoid re-announcing the same player on every audio packet.
+     */
+    private UUID lastAnnouncedPlayerId = null;
+
+    /**
      * {@code true} when the session was opened in system-controlled (mumbling) mode.
      * Determines which system prompt is used at connection time.
      */
@@ -113,6 +119,23 @@ public class CitizenWsClient extends GeminiWsClient {
         this.player = player;
         this.onSystemConversationEnded = null;
         this.playerInputStarted = false;
+        this.lastAnnouncedPlayerId = null;
+    }
+
+    /**
+     * If {@code speaker} is different from the last player the AI was told
+     * about, injects a short text attribution so the AI knows who is speaking.
+     * Safe to call before every audio or text chunk — it is a no-op when the
+     * speaker has not changed.
+     */
+    public void announcePlayerIfChanged(ServerPlayer speaker) {
+        if (speaker == null) return;
+        UUID speakerId = speaker.getUUID();
+        if (speakerId.equals(lastAnnouncedPlayerId)) return;
+        lastAnnouncedPlayerId = speakerId;
+        String name = speaker.getName().getString();
+        String attribution = "[" + name + " is now speaking to you]";
+        addPromptTextImmediate(attribution);
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/me/sshcrack/mc_talking/manager/CitizenWsClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/CitizenWsClient.java
@@ -134,6 +134,7 @@ public class CitizenWsClient extends GeminiWsClient {
         if (speakerId.equals(lastAnnouncedPlayerId)) return;
         lastAnnouncedPlayerId = speakerId;
         String name = speaker.getName().getString();
+        McTalking.LOGGER.info("[CitizenWsClient] Player changed -> announcing '{}' to AI for citizen {}", name, getEntity().getUUID());
         String attribution = "[" + name + " is now speaking to you]";
         addPromptTextImmediate(attribution);
     }

--- a/src/main/java/me/sshcrack/mc_talking/manager/CitizenWsClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/CitizenWsClient.java
@@ -134,7 +134,6 @@ public class CitizenWsClient extends GeminiWsClient {
         if (speakerId.equals(lastAnnouncedPlayerId)) return;
         lastAnnouncedPlayerId = speakerId;
         String name = speaker.getName().getString();
-        McTalking.LOGGER.info("[CitizenWsClient] Player changed -> announcing '{}' to AI for citizen {}", name, getEntity().getUUID());
         String attribution = "[" + name + " is now speaking to you]";
         addPromptTextImmediate(attribution);
     }

--- a/src/main/java/me/sshcrack/mc_talking/manager/DefaultCitizenPromptProvider.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/DefaultCitizenPromptProvider.java
@@ -372,7 +372,8 @@ public class DefaultCitizenPromptProvider implements CitizenPromptProvider {
 
         var relation = view.playerRelation();
         if (relation != null) {
-            prompt.append("- Address player as ").append(relation.playerName()).append(", he has the role of a ").append(relation.rankName()).append("\n");
+            prompt.append("- The colony has multiple players. When someone speaks to you, a context message like [PlayerName is now speaking to you] will appear. Always address that person by their announced name.\n");
+            prompt.append("- Default speaking player: ").append(relation.playerName()).append(" (role: ").append(relation.rankName()).append(")\n");
 
             if (relation.hostile()) {
                 prompt.append("- Be guarded and suspicious toward the player\n");


### PR DESCRIPTION
## Problem

In multiplayer, when a citizen's conversation was started by one player (Player A) but a *different* player (Player B) speaks to the citizen or delivers an item, the AI keeps calling the responder by the name of the *original* conversation partner.

**Example:**
```
NPC:      Hey Player A, I need [item]
Player A: Ok
Player B: Here's that item you asked for (to the NPC)
NPC:      Oh thanks so much Player A   ← WRONG – should say Player B
```

## Root Cause

The system prompt is built once at session start and encodes only the original player's name via `PlayerRelationView`. The Gemini Live API cannot swap system prompts mid-session, and audio chunks are forwarded without any text attribution telling the AI whose voice it heard.

## Fix

Before forwarding any player's audio to the citizen's Gemini session, inject a short bracketed attribution message so the AI always knows who is speaking:

### Changes

| File | Change |
|---|---|
| `CitizenWsClient.java` | Added `lastAnnouncedPlayerId` field and `announcePlayerIfChanged()` method; reset field in `transitionToPlayer()` |
| `McTalkingVoicechatPlugin.java` | Call `announcePlayerIfChanged()` before `promptAudioOpus()` in `handleMicPacket()` |
| `DefaultCitizenPromptProvider.java` | Updated system prompt to inform AI about multi-player context and the bracket convention |

### Why This Approach

- **No session restart needed** — Gemini Live API system prompt cannot be changed mid-session; injecting a real-time text turn is the only supported mechanism
- **No multi-player session redesign** — `ConversationManager` 1:1 mapping is unchanged. Any nearby player can speak into an ongoing conversation
- **Minimal diff** — three localised changes, no new maps or managers
- **No regression for singleplayer** — `announcePlayerIfChanged` fires once for the first audio packet and is a no-op thereafter

Closes #71
