### PR TITLE
refactor: encapsulate AITools, add isPlayerOnly field, unify tool declarations

### DIFF
--- a/src/main/java/me/sshcrack/mc_talking/commands/ListToolsCommand.java
+++ b/src/main/java/me/sshcrack/mc_talking/commands/ListToolsCommand.java
@@ -23,7 +23,7 @@ public class ListToolsCommand {
     private static int get_description(CommandContext<CommandSourceStack> context, String toolName) throws CommandSyntaxException {
         var src = context.getSource();
 
-        var tool = AITools.registeredFunctions.get(toolName);
+        var tool = AITools.getAction(toolName);
         if (tool == null) {
             throw TOOL_NOT_FOUND.create();
         }
@@ -51,7 +51,15 @@ public class ListToolsCommand {
             });
         }
 
-        src.sendSuccess(() -> Component.translatable("mc_talking.commands.tool_description", toolName, tool.getDescription(), strWriter.toString()), true);
+        var categoryKey = AITools.isPlayerOnlyAction(toolName)
+                ? "mc_talking.commands.tool_category_player"
+                : "mc_talking.commands.tool_category_general";
+
+        src.sendSuccess(() -> Component.translatable("mc_talking.commands.tool_description",
+                toolName,
+                Component.translatable(categoryKey),
+                tool.getDescription(),
+                strWriter.toString()), true);
         return 0;
     }
 
@@ -72,7 +80,18 @@ public class ListToolsCommand {
                         throw NO_TOOLS.create();
                     }
 
-                    src.sendSuccess(() -> Component.translatable("mc_talking.commands.list_tools", String.join(", ", tools)), true);
+                    src.sendSuccess(() -> {
+                        var message = Component.translatable("mc_talking.commands.list_tools_header");
+                        for (var name : tools) {
+                            var categoryKey = AITools.isPlayerOnlyAction(name)
+                                    ? "mc_talking.commands.tool_category_player"
+                                    : "mc_talking.commands.tool_category_general";
+                            message = message.append("\n").append(Component.translatable("mc_talking.commands.tool_entry",
+                                    name,
+                                    Component.translatable(categoryKey)));
+                        }
+                        return message;
+                    }, true);
                     return 1;
                 }));
     }

--- a/src/main/java/me/sshcrack/mc_talking/manager/GeminiWsClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/GeminiWsClient.java
@@ -287,9 +287,7 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
 
         setup.systemInstruction = sys;
 
-        boolean isPlayer = resolveActivePlayer() != null;
-        McTalking.LOGGER.info("Adding tools (player enabled {})", isPlayer);
-        setup.tools.addAll(AITools.getEnabledTools(isPlayer));
+        setup.tools.addAll(AITools.getEnabledTools());
 
         return setup;
     }
@@ -573,11 +571,18 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
     public JsonObject onFunctionCall(String name, @Nullable JsonObject args) {
         var colony = this.entity.getCitizenColonyHandler().getColony();
 
-        var action = AITools.registeredFunctions.get(name);
+        var action = AITools.getAction(name);
         if (action == null) {
             McTalking.LOGGER.warn("Unknown function call: {}", name);
             var error = new JsonObject();
             error.addProperty("error", "Unknown function: " + name);
+            return error;
+        }
+
+        if (AITools.isPlayerOnlyAction(name) && resolveActivePlayer() == null) {
+            McTalking.LOGGER.warn("Player-only tool {} called without active player", name);
+            var error = new JsonObject();
+            error.addProperty("error", "You cannot use this tool until a player is speaking to you directly.");
             return error;
         }
 

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/AITools.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/AITools.java
@@ -14,36 +14,42 @@ public class AITools {
         /* This utility class should not be instantiated */
     }
 
-    public static final Map<String, FunctionAction> registeredFunctions = new HashMap<>();
-    public static final Map<String, FunctionAction> playerConversationOnlyTools = new HashMap<>();
+    private static final Map<String, FunctionAction> registeredFunctions = new HashMap<>();
+    private static final Map<String, FunctionAction> playerConversationOnlyTools = new HashMap<>();
 
-    public static void add(Map<String, FunctionAction> map, FunctionAction action) {
-        map.put(action.getName(), action);
-    }
-
-    public static void addAll(Map<String, FunctionAction> map, List<FunctionAction> actions) {
+    private static void addAll(Map<String, FunctionAction> map, List<FunctionAction> actions) {
         for (var action : actions) {
-            add(map, action);
+            map.put(action.getName(), action);
         }
     }
 
-    public static List<String> getRegisteredFunctionNames() {
-        return new ArrayList<>(registeredFunctions.keySet());
+    public static FunctionAction getAction(String name) {
+        var action = registeredFunctions.get(name);
+        if (action != null) return action;
+        return playerConversationOnlyTools.get(name);
     }
 
-    public static List<BidiGenerateContentSetup.Tool> getEnabledTools(boolean isPlayerConversation) {
+    public static boolean isPlayerOnlyAction(String name) {
+        var action = getAction(name);
+        return action != null && action.isPlayerOnly();
+    }
+
+    public static List<String> getRegisteredFunctionNames() {
+        var names = new ArrayList<>(registeredFunctions.keySet());
+        names.addAll(playerConversationOnlyTools.keySet());
+        return names;
+    }
+
+    public static List<BidiGenerateContentSetup.Tool> getEnabledTools() {
         var list = new ArrayList<BidiGenerateContentSetup.Tool>();
 
         var tool = new BidiGenerateContentSetup.Tool();
         var rawToolsDisabled = McTalkingConfig.INSTANCE.instance().disabledTools;
 
-        var functions = registeredFunctions
-                .values()
-                .stream();
-
-        if (isPlayerConversation) {
-            functions = Stream.concat(functions, playerConversationOnlyTools.values().stream());
-        }
+        var functions = Stream.concat(
+                registeredFunctions.values().stream(),
+                playerConversationOnlyTools.values().stream()
+        );
 
         tool.functionDeclarations.addAll(
                 functions

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/AddEventToMemory.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/AddEventToMemory.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 
-public class AddEventToMemory extends FunctionAction {
+public class AddEventToMemory extends GeneralFunctionAction {
     public AddEventToMemory() {
         super("add_event_to_memory", """
                         Adds a message to your memory, so you remember it in ongoing conversations.

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/DescribeSurroundingsAction.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/DescribeSurroundingsAction.java
@@ -23,7 +23,7 @@ import java.util.Set;
  * immediate surroundings: time, weather, nearby players, other citizens,
  * animals, hostile mobs, and visible colony buildings.
  */
-public class DescribeSurroundingsAction extends FunctionAction {
+public class DescribeSurroundingsAction extends GeneralFunctionAction {
 
     private static final double SCAN_RADIUS = 20.0;
 

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/DropItemAction.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/DropItemAction.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 
-public class DropItemAction extends FunctionAction {
+public class DropItemAction extends PlayerFunctionAction {
 
     public DropItemAction() {
         super("drop_item", "Drops an item with the given count at the specified slot in your inventory. Use -1 to drop the entire stack (maximum count).",

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/EndConversationAction.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/EndConversationAction.java
@@ -9,7 +9,7 @@ import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class EndConversationAction extends FunctionAction {
+public class EndConversationAction extends GeneralFunctionAction {
     public EndConversationAction() {
         super("end_conversation", """
                 This will end the conversation. The peer you are talking to isn't able to respond after. Only use if you are sure you want to end the conversation.

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/FunctionAction.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/FunctionAction.java
@@ -18,15 +18,17 @@ public abstract class FunctionAction {
     private final String name;
     private final String description;
     private final Property property;
+    private final boolean isPlayerOnly;
 
-    public FunctionAction(String name, String description) {
-        this(name, description, null);
+    public FunctionAction(String name, String description, boolean isPlayerOnly) {
+        this(name, description, null, isPlayerOnly);
     }
 
-    public FunctionAction(String name, String description, Property property) {
+    public FunctionAction(String name, String description, Property property, boolean isPlayerOnly) {
         this.name = name;
         this.description = description;
         this.property = property;
+        this.isPlayerOnly = isPlayerOnly;
     }
 
     public Property getProperty() {
@@ -39,6 +41,10 @@ public abstract class FunctionAction {
 
     public String getDescription() {
         return description;
+    }
+
+    public boolean isPlayerOnly() {
+        return isPlayerOnly;
     }
 
     public boolean isEnabled() {

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/GeneralFunctionAction.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/GeneralFunctionAction.java
@@ -1,0 +1,13 @@
+package me.sshcrack.mc_talking.manager.tools;
+
+import me.sshcrack.gemini_live_lib.gson.properties.Property;
+
+public abstract class GeneralFunctionAction extends FunctionAction {
+    public GeneralFunctionAction(String name, String description) {
+        super(name, description, false);
+    }
+
+    public GeneralFunctionAction(String name, String description, Property property) {
+        super(name, description, property, false);
+    }
+}

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/GetCitizenInfoAction.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/GetCitizenInfoAction.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 
-public class GetCitizenInfoAction extends FunctionAction {
+public class GetCitizenInfoAction extends GeneralFunctionAction {
     public GetCitizenInfoAction() {
         super(
                 "get_citizen_info",

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/GetColonyAction.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/GetColonyAction.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.List;
 
-public class GetColonyAction extends FunctionAction {
+public class GetColonyAction extends GeneralFunctionAction {
     public GetColonyAction() {
         super("get_colony", "Gets information about the colony. If no colony ID is provided, it returns the colony the citizen is currently living in. This includes the name of the colony, buildings, maxCitizens, overallHappiness and other useful information.",
                 new ObjectProperty(new HashMap<>() {{

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/GetInventoryAction.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/GetInventoryAction.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.stream.Collectors;
 
-public class GetInventoryAction extends FunctionAction {
+public class GetInventoryAction extends GeneralFunctionAction {
     public GetInventoryAction() {
         super("get_inventory", "Lists the current items in your inventory.");
     }

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/LeaveColonyAction.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/LeaveColonyAction.java
@@ -35,7 +35,7 @@ import java.util.List;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_ID;
 import static com.minecolonies.api.util.constant.SchematicTagConstants.TAG_SITTING;
 
-public class LeaveColonyAction extends FunctionAction {
+public class LeaveColonyAction extends PlayerFunctionAction {
     @SuppressWarnings("SpellCheckingInspection")
     private static final String TAG_RECRUIT_COST = "rcost";
     @SuppressWarnings("SpellCheckingInspection")

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/ListCitizenAction.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/ListCitizenAction.java
@@ -8,7 +8,7 @@ import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class ListCitizenAction extends FunctionAction {
+public class ListCitizenAction extends GeneralFunctionAction {
     public ListCitizenAction() {
         super("list_citizens", "Listens all citizens in the colony by their names.");
     }

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/PlayerFunctionAction.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/PlayerFunctionAction.java
@@ -1,0 +1,15 @@
+package me.sshcrack.mc_talking.manager.tools;
+
+import me.sshcrack.gemini_live_lib.gson.properties.Property;
+
+public abstract class PlayerFunctionAction extends FunctionAction {
+    private static final String PLAYER_ONLY_SUFFIX = "\n\nNOTE: This tool is ONLY callable when a player is speaking to you directly.";
+
+    public PlayerFunctionAction(String name, String description) {
+        super(name, description + PLAYER_ONLY_SUFFIX, null, true);
+    }
+
+    public PlayerFunctionAction(String name, String description, Property property) {
+        super(name, description + PLAYER_ONLY_SUFFIX, property, true);
+    }
+}

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/RecordRelationshipChange.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/RecordRelationshipChange.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 import java.util.HashMap;
 
-public class RecordRelationshipChange extends FunctionAction {
+public class RecordRelationshipChange extends GeneralFunctionAction {
     public RecordRelationshipChange() {
         super("record_relationship_change", """
                         Updates your emotional feelings and relationship in your memory targeting a citizen or the player you are talking to. Leave the citizen name, if you want to update the memory to the player (or manager)

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/specific/JobSpecificAction.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/specific/JobSpecificAction.java
@@ -4,14 +4,14 @@ import com.google.gson.JsonObject;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import me.sshcrack.gemini_live_lib.gson.properties.ObjectProperty;
-import me.sshcrack.mc_talking.manager.tools.FunctionAction;
+import me.sshcrack.mc_talking.manager.tools.GeneralFunctionAction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 
 //TODO: Implement job-specific actions
-public class JobSpecificAction extends FunctionAction {
+public class JobSpecificAction extends GeneralFunctionAction {
     public JobSpecificAction() {
         super("job_action", "Performs a job-specific action for the citizen. To get available actions use 'list_job_actions'.",
                 new ObjectProperty(new HashMap<>() {{

--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/specific/ListJobSpecificAction.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/specific/ListJobSpecificAction.java
@@ -4,11 +4,11 @@ package me.sshcrack.mc_talking.manager.tools.specific;
 import com.google.gson.JsonObject;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
-import me.sshcrack.mc_talking.manager.tools.FunctionAction;
+import me.sshcrack.mc_talking.manager.tools.GeneralFunctionAction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class ListJobSpecificAction extends FunctionAction {
+public class ListJobSpecificAction extends GeneralFunctionAction {
     public ListJobSpecificAction() {
         super("list_job_actions", "Lists all available job-specific actions for the citizen. " +
                 "To perform a job-specific action use 'job_action'.");

--- a/src/main/resources/assets/mc_talking/lang/en_us.json
+++ b/src/main/resources/assets/mc_talking/lang/en_us.json
@@ -53,8 +53,11 @@
   "mc_talking.commands.invalid_tool": "Invalid tool name: %s",
   "mc_talking.commands.tool_not_found": "Tool not found.",
   "mc_talking.commands.no_tools_available": "No tools available.",
-  "mc_talking.commands.tool_description": "The description of tool %s is:\n%s\nProperties:%s",
-  "mc_talking.commands.list_tools": "List of available tools:\n%s",
+  "mc_talking.commands.tool_description": "The description of tool %s (%s) is:\n%s\nProperties:%s",
+  "mc_talking.commands.list_tools_header": "List of available tools:",
+  "mc_talking.commands.tool_entry": "  %s (%s)",
+  "mc_talking.commands.tool_category_player": "player-only",
+  "mc_talking.commands.tool_category_general": "general",
 
   "mc_talking.debug.not_citizen": "Target must be a MineColonies citizen.",
   "mc_talking.debug.not_player": "Command must be executed by a player.",


### PR DESCRIPTION
## Summary

Refactors the AITools system to use proper encapsulation, always-declared tools, and runtime gating for player-only actions.

## Changes

### AITools encapsulation
- `registeredFunctions` and `playerConversationOnlyTools` maps are now **private**
- Added `getAction(name)` for unified lookup across both maps
- Added `isPlayerOnlyAction(name)` for runtime guard checks

### Unified tool declarations
- All tools (including player-only) are **always declared to Gemini** at session setup
- Player-only tools (`drop_item`, `leave_colony`) are **guarded at call-time** in `onFunctionCall()` — if the AI calls them without an active player, it receives: *"You cannot use this tool until a player is speaking to you directly."*
- Removed the `isPlayerConversation` branching in `getEnabledTools()`

### Type-safe tool hierarchy
- Added `isPlayerOnly` field to `FunctionAction`
- Created `GeneralFunctionAction` (isPlayerOnly=false) and `PlayerFunctionAction` (isPlayerOnly=true) abstract subclasses
- `PlayerFunctionAction` auto-appends a restriction notice to the tool description
- All 10 tool implementations updated to extend the appropriate subclass

### ListToolsCommand improvements
- Shows `(player-only)` or `(general)` category for each tool
- Uses new `getAction()` API instead of direct map field access