### PR TITLE
Enhance happiness modifier prompts with accurate Minecolonies reasons

### DIFF
--- a/src/main/java/me/sshcrack/mc_talking/manager/DefaultCitizenPromptProvider.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/DefaultCitizenPromptProvider.java
@@ -8,6 +8,7 @@ import me.sshcrack.mc_talking.api.prompt.view.HappinessModifierType;
 import me.sshcrack.mc_talking.api.prompt.view.SkillLevelView;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
 import me.sshcrack.mc_talking.util.ColonyEventBuffer;
+import me.sshcrack.mc_talking.util.MiscUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -418,94 +419,261 @@ public class DefaultCitizenPromptProvider implements CitizenPromptProvider {
         for (var modifier : view.happinessModifiers()) {
             HappinessModifierType modifierType = modifier.type();
             double factor = modifier.factor();
-            if (factor < 0.8 || factor > 1.2) {
-                switch (modifierType) {
-                    case HOMELESSNESS:
-                        if (factor < 0.8 && !view.guard()) {
-                            prompt.append("- Distressed about housing situation\n");
+
+            switch (modifierType) {
+                case HOMELESSNESS:
+                    if (factor < 0.8 && !view.guard()) {
+                        if (factor < 0.3) {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "Sleeping without a proper roof over your head is wearing on you",
+                                "You desperately need a home — living like this is getting unbearable",
+                                "Not having a decent place to live is one of your biggest worries"
+                            )).append("\n");
+                        } else {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "Your current housing is cramped and basic — you wish for something better",
+                                "The shack you're living in barely counts as a proper home",
+                                "Your housing situation could be a lot better than this"
+                            )).append("\n");
                         }
-                        break;
-                    case UNEMPLOYMENT:
-                        if (factor < 0.8) {
-                            prompt.append("- Anxious about employment status\n");
+                    } else if (factor > 1.2) {
+                        prompt.append("- ").append(MiscUtil.pick(
+                            "You're proud of your nice home — it's comfortable and well-appointed",
+                            "Your house is one of the best in the colony and you love coming home to it",
+                            "Living in such a high-quality home makes you feel fortunate"
+                        )).append("\n");
+                    }
+                    break;
+
+                case UNEMPLOYMENT:
+                    if (factor < 0.8) {
+                        if (factor < 0.4) {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "You've been without a job for so long it's making you feel worthless",
+                                "The desperate need for meaningful work has been gnawing at you for weeks",
+                                "Watching everyone else contribute while you remain unemployed is crushing"
+                            )).append("\n");
+                        } else {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "You feel useless without work — everyone else has a purpose except you",
+                                "You desperately want a job so you can contribute to the colony",
+                                "Not having a job makes you feel like you don't belong here"
+                            )).append("\n");
                         }
-                        break;
-                    case HEALTH:
-                        if (factor < 0.8) {
-                            prompt.append("- Concerned about health issues\n");
+                    } else if (factor > 1.2) {
+                        prompt.append("- ").append(MiscUtil.pick(
+                            "You take great pride in your high-level position — your expertise is respected",
+                            "Working at such an advanced workplace makes you feel valued and accomplished",
+                            "Your job is fulfilling and you're proud of the skills you've developed"
+                        )).append("\n");
+                    }
+                    break;
+
+                case HEALTH:
+                    if (factor < 0.8) {
+                        if (factor < 0.3) {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "This illness has been dragging on for so long — you're desperate for a cure",
+                                "You've been sick for what feels like forever and it's draining all your strength",
+                                "The prolonged sickness is unbearable — you need medical help urgently"
+                            )).append("\n");
+                        } else {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "You feel terrible — this illness is really taking it out of you",
+                                "Being sick makes everything harder. You wish the hospital would help",
+                                "Your body aches and you can't focus through the fever and discomfort"
+                            )).append("\n");
                         }
-                        break;
-                    case IDLEATJOB:
-                        if (factor < 0.8) {
-                            prompt.append("- Frustrated by lack of work to do\n");
+                    }
+                    break;
+
+                case IDLEATJOB:
+                    if (factor < 0.8) {
+                        if (factor < 0.3) {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "You've been idle at work for weeks — missing tools or supplies are making your life impossible",
+                                "Being unable to work for so long is driving you crazy — someone needs to fix the supply issue",
+                                "You're at your wit's end — your workplace has been non-functional for too long"
+                            )).append("\n");
+                        } else {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "You're stuck idle at your job because of missing tools or supplies — it's maddening",
+                                "You want to work but can't — something essential is missing from your workplace",
+                                "Standing around with nothing productive to do at your job is frustrating"
+                            )).append("\n");
                         }
-                        break;
-                    case SCHOOL:
-                        if (factor < 0.8) {
-                            if (view.hasSchool()) {
-                                prompt.append("- Disappointed by lack of school activities\n");
+                    }
+                    break;
+
+                case SCHOOL:
+                    if (factor < 0.8) {
+                        if (view.hasSchool()) {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "You wish you could attend the school like the other kids instead of wandering around",
+                                "Seeing other children go to school while you're left out makes you sad",
+                                "You want to learn and play at school but something is holding you back"
+                            )).append("\n");
+                        } else {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "You wish the colony had a school — all the other kids get to learn and you're stuck here",
+                                "Being a child with no school to attend is boring — you want to learn new things",
+                                "Without a school in the colony, you feel like you're missing out on growing up"
+                            )).append("\n");
+                        }
+                    } else if (factor > 1.2) {
+                        prompt.append("- ").append(MiscUtil.pick(
+                            "School has been wonderful — you're learning so much every day",
+                            "You love your teacher and the lessons at school are fascinating",
+                            "Going to school makes you feel important and you're making great progress"
+                        )).append("\n");
+                    }
+                    break;
+
+                case MYSTICAL_SITE:
+                    if (factor > 1.2) {
+                        prompt.append("- ").append(MiscUtil.pick(
+                            "You love visiting the mystical site — it fills you with wonder and energy",
+                            "The mystical site is one of your favorite places in the colony",
+                            "There's something magical about the mystical site that lifts your spirits every time"
+                        )).append("\n");
+                    }
+                    break;
+
+                case SECURITY:
+                    if (factor < 0.8) {
+                        if (!view.peaceful()) {
+                            if (factor < 0.3) {
+                                prompt.append("- ").append(MiscUtil.pick(
+                                    "You feel terrified — there are hardly any guards to protect the colony",
+                                    "Every noise at night makes you jump — the colony desperately needs more guards",
+                                    "You can't sleep knowing how vulnerable the colony is with so few defenders"
+                                )).append("\n");
                             } else {
-                                prompt.append("- Disappointed by lack of school in the colony\n");
+                                prompt.append("- ").append(MiscUtil.pick(
+                                    "You wish there were more guards patrolling the colony",
+                                    "The guard presence feels a bit thin for comfort lately",
+                                    "You'd feel a lot safer if there were more guards watching over things"
+                                )).append("\n");
                             }
                         }
-                        if (factor > 1.2) {
-                            prompt.append("- Enjoying school activities\n");
-                        }
-                        break;
-                    case MYSTICAL_SITE:
-                        if (factor < 0.8) {
-                            prompt.append("- Disappointed by lack of mystical experiences\n");
+                    } else if (factor > 1.2) {
+                        if (factor > 1.5) {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "Knowing so many capable guards protect the colony puts your mind completely at ease",
+                                "The guards are doing a phenomenal job — you feel incredibly safe and grateful",
+                                "You sleep soundly every night knowing the guards have everything under control"
+                            )).append("\n");
                         } else {
-                            prompt.append("- Enjoying mystical site visits\n");
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "You feel quite safe with the current guard presence in the colony",
+                                "The guards are doing a decent job keeping everyone protected",
+                                "It's reassuring to see guards patrolling — you feel reasonably secure"
+                            )).append("\n");
                         }
-                        break;
-                    case SECURITY:
-                        if (factor < 0.8) {
-                            if (!view.peaceful()) {
-                                prompt.append("- Feels unsafe in the colony\n");
-                            }
+                    }
+                    break;
+
+                case SOCIAL:
+                    if (factor < 0.8) {
+                        if (factor < 0.5) {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "Seeing so many fellow citizens sick, hungry, or homeless is devastating",
+                                "The colony's morale is in shambles — suffering is everywhere you look",
+                                "It's impossible to be happy when so many of your neighbors are in such dire straits"
+                            )).append("\n");
                         } else {
-                            prompt.append("- Feels very secure in the colony\n");
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "Seeing fellow citizens unhappy or struggling brings you down",
+                                "The colony's morale could be better — too many people are dealing with problems",
+                                "It's hard to stay cheerful when some of your neighbors are suffering"
+                            )).append("\n");
                         }
-                        break;
-                    case SOCIAL:
-                        if (factor < 0.8) {
-                            prompt.append("- Feeling socially isolated\n");
+                    }
+                    break;
+
+                case DAMAGE:
+                    if (factor < 0.8) {
+                        prompt.append("- ").append(MiscUtil.pick(
+                            "You're still recovering from a recent injury — it hurts to move",
+                            "The wounds from that fight haven't healed yet and they ache constantly",
+                            "You got hurt recently and the pain is still fresh with every step"
+                        )).append("\n");
+                    }
+                    break;
+
+                case DEATH:
+                    if (factor < 0.8) {
+                        prompt.append("- ").append(MiscUtil.pick(
+                            "The recent death of a fellow colonist weighs heavily on your heart",
+                            "You can't stop thinking about the colonist who passed away — the colony feels emptier",
+                            "Mourning the loss of a fellow colonist has left you feeling somber and reflective"
+                        )).append("\n");
+                    }
+                    break;
+
+                case RAIDWITHOUTDEATH:
+                    if (!view.peaceful() && factor > 1.2) {
+                        prompt.append("- ").append(MiscUtil.pick(
+                            "Surviving the raid without any casualties filled you with relief and pride",
+                            "The colony stood strong against the raid — no one died and you're feeling confident",
+                            "That last raid was scary, but everyone made it through alive — what a relief"
+                        )).append("\n");
+                    }
+                    break;
+
+                case FOOD:
+                    if (factor < 0.8) {
+                        if (factor < 0.4) {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "The food situation is dire — barely any variety and mostly tasteless vanilla scraps. The colony needs proper Minecolonies meals",
+                                "You're tired of eating the same plain food over and over. You'd kill for some decent tier 2 or 3 cooking",
+                                "Your recent meals have been awful — no variety, no quality. The dining hall menu desperately needs improvement"
+                            )).append("\n");
                         } else {
-                            prompt.append("- Enjoying colony social life\n");
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "You wish the dining hall had more variety — eating the same few things gets old fast",
+                                "The food quality has been lacking lately. Some proper Minecolonies dishes with real ingredients would go a long way",
+                                "Your meals have been pretty basic — mostly vanilla food that just doesn't satisfy like proper colony cooking"
+                            )).append("\n");
                         }
-                        break;
-                    case DAMAGE:
-                        if (factor < 0.8) {
-                            prompt.append("- Have been injured recently\n");
-                        }
-                        break;
-                    case DEATH:
-                        if (factor < 0.8) {
-                            prompt.append("- Distressed by recent death in the colony\n");
-                        }
-                        break;
-                    case RAIDWITHOUTDEATH:
-                        if (!view.peaceful() && factor > 1.2) {
-                            prompt.append("- Feeling safe because the recent raid was without civilian deaths\n");
-                        }
-                        break;
-                    case FOOD:
-                        if (factor < 0.8) {
-                            prompt.append("- Unhappy with food quality/variety\n");
+                    } else if (factor > 1.2) {
+                        if (factor > 2.5) {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "You're eating like royalty! The variety and quality of food is outstanding — plenty of high-tier dishes to enjoy",
+                                "Every meal has been a delight — the colony's food situation is absolutely superb right now",
+                                "You can't remember the last time you had a bad meal — the dining hall is doing an amazing job with diverse, high-quality food"
+                            )).append("\n");
                         } else {
-                            prompt.append("- Very satisfied with food quality\n");
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "The food has been quite good lately — decent variety and some nice Minecolonies meals",
+                                "You're happy with the dining hall's recent menu — much better selection than before",
+                                "Your meals have been satisfying with a good mix of different foods to choose from"
+                            )).append("\n");
                         }
-                        break;
-                    case SLEPTTONIGHT:
-                        if (factor < 0.8) {
-                            prompt.append("- Tired from lack of sleep\n");
+                    }
+                    break;
+
+                case SLEPTTONIGHT:
+                    if (factor < 0.85) {
+                        if (factor < 0.6) {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "You're exhausted from lack of sleep — the noise and disruptions have been keeping you up for nights",
+                                "Not having had a proper night's rest in days is really taking a severe toll on you",
+                                "You're running on fumes — the sleep deprivation is making everything harder and you desperately need rest"
+                            )).append("\n");
+                        } else {
+                            prompt.append("- ").append(MiscUtil.pick(
+                                "You haven't slept well in a couple of nights — those disruptions keep disturbing your rest",
+                                "You're a bit tired from lack of proper sleep lately",
+                                "The nights have been restless — you could really use an uninterrupted sleep"
+                            )).append("\n");
                         }
-                        break;
-                    case UNKNOWN:
-                    default:
-                        break;
-                }
+                    }
+                    break;
+
+                case UNKNOWN:
+                default:
+                    break;
             }
         }
     }

--- a/src/main/java/me/sshcrack/mc_talking/util/ColonyStatsHelper.java
+++ b/src/main/java/me/sshcrack/mc_talking/util/ColonyStatsHelper.java
@@ -7,7 +7,6 @@ import me.sshcrack.mc_talking.config.McTalkingConfig;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 
 public final class ColonyStatsHelper {
 
@@ -74,10 +73,6 @@ public final class ColonyStatsHelper {
         }
 
         if (eligible.isEmpty()) return null;
-        return pick(eligible.toArray(new String[0]));
-    }
-
-    private static String pick(String... options) {
-        return options[ThreadLocalRandom.current().nextInt(options.length)];
+        return MiscUtil.pick(eligible.toArray(new String[0]));
     }
 }

--- a/src/main/java/me/sshcrack/mc_talking/util/MiscUtil.java
+++ b/src/main/java/me/sshcrack/mc_talking/util/MiscUtil.java
@@ -1,5 +1,7 @@
 package me.sshcrack.mc_talking.util;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 public class MiscUtil {
     public static String describeTime(long dayTime) {
         if (dayTime < 1000) return "early morning (sunrise)";
@@ -10,5 +12,9 @@ public class MiscUtil {
         if (dayTime < 18000) return "night";
         if (dayTime < 22000) return "late night";
         return "pre-dawn";
+    }
+
+    public static String pick(String... options) {
+        return options[ThreadLocalRandom.current().nextInt(options.length)];
     }
 }

--- a/src/main/java/me/sshcrack/mc_talking/util/MumblingTopicHelper.java
+++ b/src/main/java/me/sshcrack/mc_talking/util/MumblingTopicHelper.java
@@ -114,7 +114,7 @@ public final class MumblingTopicHelper {
 
         // ── Mining ────────────────────────────────────────────────────────────
         if (job == ModJobs.miner.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about what veins might lie deeper in the rock.",
                     "You're wondering whether the shaft you dug will hold.",
                     "You're mulling over a strange formation you spotted earlier.",
@@ -123,7 +123,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.quarrier.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about the sheer volume of stone left to move.",
                     "You're sore from the work but not about to stop.",
                     "You're planning the next section of the quarry in your head."
@@ -132,7 +132,7 @@ public final class MumblingTopicHelper {
 
         // ── Stone / crushing ─────────────────────────────────────────────────
         if (job == ModJobs.crusher.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about the rhythm of the work — grind, sort, repeat.",
                     "You're wondering if you're getting the ratios right.",
                     "You're working through a minor frustration with the material."
@@ -140,7 +140,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.stoneMason.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about how to get the joints tighter.",
                     "You're picturing the finished structure in your head.",
                     "You're going over which cuts still need to be made."
@@ -149,7 +149,7 @@ public final class MumblingTopicHelper {
 
         // ── Farming / plants ─────────────────────────────────────────────────
         if (job == ModJobs.farmer.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're watching how the crops are coming in.",
                     "You're thinking about which fields need attention next.",
                     "You're hoping the yield holds up this season."
@@ -157,7 +157,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.planter.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about which spots still need planting.",
                     "You're wondering if the saplings will take.",
                     "You're going over your planting plan in your head."
@@ -165,7 +165,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.florist.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're keeping an eye on how the flowers are coming along.",
                     "You're thinking about what blooms might come next.",
                     "You're quietly enjoying the colour around you."
@@ -174,7 +174,7 @@ public final class MumblingTopicHelper {
 
         // ── Druid / nature ───────────────────────────────────────────────────
         if (job == ModJobs.druid.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're sensing something subtle in the environment.",
                     "You're thinking about the balance of things — something feels off.",
                     "You're paying close attention to patterns others ignore."
@@ -182,7 +182,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.beekeeper.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're listening to the hive — something in the sound tells you things.",
                     "You're thinking about the colony and whether it's healthy.",
                     "You're noting which flowers are getting the most attention today."
@@ -191,7 +191,7 @@ public final class MumblingTopicHelper {
 
         // ── Animal handling ──────────────────────────────────────────────────
         if (job == ModJobs.shepherd.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're counting your flock in your head.",
                     "You're thinking about that one sheep that keeps wandering.",
                     "You're watching for anything that might startle them."
@@ -199,7 +199,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.cowboy.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about which cattle need checking on.",
                     "You're tracking something one of the animals did earlier.",
                     "You're keeping an eye out — they can be unpredictable."
@@ -207,7 +207,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.swineHerder.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about keeping the pigs under control.",
                     "You're a bit exasperated — they're not the easiest to manage.",
                     "You're watching to make sure none of them wander off."
@@ -215,7 +215,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.chickenHerder.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're keeping track of the flock and whether anything's missing.",
                     "You're thinking about the noise — it's been busier than usual.",
                     "You're watching one of them that's been acting oddly."
@@ -223,7 +223,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.rabbitHerder.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're making sure none of them have found a gap to slip through.",
                     "You're thinking about how fast they breed — it's a lot to manage.",
                     "You're watching one that keeps pushing the boundaries."
@@ -232,7 +232,7 @@ public final class MumblingTopicHelper {
 
         // ── Smithing / smelting ──────────────────────────────────────────────
         if (job == ModJobs.blacksmith.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking through the next piece — weight, balance, heat.",
                     "You're replaying a strike pattern that didn't come out quite right.",
                     "You're mentally checking your stock of materials."
@@ -240,7 +240,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.smelter.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're watching the temperature in your head — it has to be exact.",
                     "You're thinking about the ore that's waiting to be processed.",
                     "You're running through the timing to make sure nothing burns."
@@ -249,7 +249,7 @@ public final class MumblingTopicHelper {
 
         // ── Crafting ─────────────────────────────────────────────────────────
         if (job == ModJobs.glassblower.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about the shape — you need a steady hand for this.",
                     "You're going over a detail that didn't come out how you wanted.",
                     "You're picturing the finished piece before you start."
@@ -257,7 +257,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.dyer.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about the colour balance — it needs to be right.",
                     "You're mentally mixing the next batch.",
                     "You're wondering if the hue will hold after drying."
@@ -265,7 +265,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.fletcher.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're checking the fletching in your head — angle and weight matter.",
                     "You're thinking about how consistent your last batch was.",
                     "You're focused on the small details that make the difference."
@@ -273,7 +273,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.mechanic.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're running through how a mechanism fits together.",
                     "You're thinking about a component that might wear out soon.",
                     "You're troubleshooting something in your head."
@@ -281,7 +281,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.concreteMixer.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about getting the mix right this time.",
                     "You're focused on the consistency — too dry and it won't set.",
                     "You're mentally timing how long this batch needs."
@@ -290,7 +290,7 @@ public final class MumblingTopicHelper {
 
         // ── Food ─────────────────────────────────────────────────────────────
         if (job == ModJobs.cook.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking through what you're going to make next.",
                     "You're wondering if you have all the ingredients you need.",
                     "You're running through a recipe in your head, adjusting as you go."
@@ -298,7 +298,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.chef.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about how to get the flavour just right.",
                     "You're going over the order of things — timing is everything.",
                     "You're quietly critiquing the last thing you made."
@@ -306,7 +306,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.baker.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about the dough and whether it's ready.",
                     "You're watching the timing in your head — overbaking is the enemy.",
                     "You're already planning what you'll bake after this."
@@ -315,7 +315,7 @@ public final class MumblingTopicHelper {
 
         // ── Combat / guards ──────────────────────────────────────────────────
         if (job == ModJobs.knight.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're scanning for anything out of place.",
                     "You're mentally running through your patrol route.",
                     "You're on edge — quiet stretches like this make you suspicious."
@@ -323,7 +323,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.archer.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about your sight lines and whether they're covered.",
                     "You're watching for movement — a habit you can't shake.",
                     "You're quietly calculating range in the back of your mind."
@@ -332,7 +332,7 @@ public final class MumblingTopicHelper {
 
         // ── Delivery / logistics ─────────────────────────────────────────────
         if (job == ModJobs.delivery.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're mentally reordering your route for efficiency.",
                     "You're hoping you haven't left anything behind.",
                     "You're running through the list again just to be sure."
@@ -341,7 +341,7 @@ public final class MumblingTopicHelper {
 
         // ── Knowledge / magic ────────────────────────────────────────────────
         if (job == ModJobs.enchanter.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're turning over the logic of a formula that hasn't clicked yet.",
                     "You're thinking about the energy flows — something's still off.",
                     "You're replaying a recent attempt in your head, looking for the flaw."
@@ -349,7 +349,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.alchemist.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're going over the sequence — order matters more than people think.",
                     "You're thinking about a reaction that didn't behave as expected.",
                     "You're mentally cataloguing what you have and what you still need."
@@ -357,7 +357,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.researcher.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're turning a problem over in your mind from a different angle.",
                     "You're thinking about a piece of information that doesn't fit yet.",
                     "You're not sure you're asking the right question — that bothers you."
@@ -365,7 +365,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.teacher.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about how to explain something more clearly.",
                     "You're replaying a lesson that didn't land the way you wanted.",
                     "You're figuring out a better way to approach the material."
@@ -373,7 +373,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.student.get() || job == ModJobs.pupil.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're going over what you were just taught, trying to make it stick.",
                     "You're not sure you fully understood that last part.",
                     "You're replaying an explanation in your head."
@@ -382,7 +382,7 @@ public final class MumblingTopicHelper {
 
         // ── Medical ──────────────────────────────────────────────────────────
         if (job == ModJobs.healer.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about someone's condition and whether it's improving.",
                     "You're going over the treatment — wondering if you're missing something.",
                     "You're hoping your efforts are actually making a difference."
@@ -390,7 +390,7 @@ public final class MumblingTopicHelper {
         }
 
         if (job == ModJobs.undertaker.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking quietly about those who've passed.",
                     "You're carrying a weight that doesn't leave you easily.",
                     "You're focused on doing this right — it's the least they deserve."
@@ -399,7 +399,7 @@ public final class MumblingTopicHelper {
 
         // ── Exotic ───────────────────────────────────────────────────────────
         if (job == ModJobs.netherworker.get()) {
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about what's waiting for you down there.",
                     "You're still processing something you saw on your last trip.",
                     "You're uneasy — the Nether has a way of getting under your skin."
@@ -418,21 +418,21 @@ public final class MumblingTopicHelper {
      */
     private static String applyMoodTint(String base, double happiness) {
         if (happiness < 3.0) {
-            return base + " " + pick(
+            return base + " " + MiscUtil.pick(
                     "A creeping frustration sits just beneath the surface.",
                     "There's a persistent dissatisfaction you can't quite shake.",
                     "Things feel harder than they should right now."
             );
         }
         if (happiness < 5.0) {
-            return base + " " + pick(
+            return base + " " + MiscUtil.pick(
                     "You're not in the best mood today.",
                     "Something's been nagging at you all day.",
                     "You're a little off — nothing feels quite right."
             );
         }
         if (happiness > 8.0) {
-            return base + " " + pick(
+            return base + " " + MiscUtil.pick(
                     "Despite everything, you're in good spirits.",
                     "Things feel like they're going well lately.",
                     "There's a quiet satisfaction underlying it all."
@@ -452,14 +452,14 @@ public final class MumblingTopicHelper {
             return "You're grieving quietly, your thoughts returning to someone you lost.";
 
         if (status == VisibleCitizenStatus.SICK || data.getCitizenDiseaseHandler().isSick())
-            return pick(
+            return MiscUtil.pick(
                     "You feel awful and can't ignore it.",
                     "You're unwell and finding it hard to concentrate.",
                     "You're trying to push through, but it's hard."
             );
 
         if (status == VisibleCitizenStatus.RAIDED && !isPeaceful(citizen))
-            return pick(
+            return MiscUtil.pick(
                     "You're still shaken by what happened.",
                     "You can't fully relax yet.",
                     "You're replaying recent events in your mind."
@@ -467,7 +467,7 @@ public final class MumblingTopicHelper {
 
         double saturation = data.getSaturation();
         if (saturation <= 1)
-            return pick(
+            return MiscUtil.pick(
                     "You're extremely hungry — it's getting hard to think straight.",
                     "The hunger is impossible to ignore now.",
                     "You're running on empty and you know it."
@@ -477,21 +477,21 @@ public final class MumblingTopicHelper {
         // WORKING is intentionally omitted — job topic is always more specific.
 
         if (status == VisibleCitizenStatus.BAD_WEATHER && chance(0.5))
-            return pick(
+            return MiscUtil.pick(
                     "You're annoyed by the weather.",
                     "The rain is getting to you.",
                     "You'd rather be doing this in better conditions."
             );
 
         if (status == VisibleCitizenStatus.EAT && chance(0.6))
-            return pick(
+            return MiscUtil.pick(
                     "You're focused on your meal.",
                     "You're savouring a moment of rest.",
                     "The food is a welcome break."
             );
 
         if (saturation <= 3 && chance(0.5))
-            return pick(
+            return MiscUtil.pick(
                     "You're thinking about food.",
                     "Your stomach reminds you it's not been long enough since you last ate.",
                     "You're keeping an eye out for a chance to grab something."
@@ -505,7 +505,7 @@ public final class MumblingTopicHelper {
      * (no other topic available to blend with).
      */
     private static String standaloneColonyTopic(String milestone) {
-        return pick(
+        return MiscUtil.pick(
                 "You're thinking about something — " + milestone.toLowerCase(),
                 "A thought crosses your mind: " + milestone.toLowerCase(),
                 "You can't help but notice that " + milestone.toLowerCase()
@@ -523,11 +523,6 @@ public final class MumblingTopicHelper {
         return level != null && level.getDifficulty() == Difficulty.PEACEFUL;
     }
 
-    private static String pick(String... options) {
-        return options[ThreadLocalRandom.current().nextInt(options.length)];
-    }
-
-
     public static String buildUrgentContactPrompt(AbstractEntityCitizen citizen, String playerName) {
         if (citizen.getCitizenData() == null) return buildGenericUrgentPrompt(playerName);
 
@@ -540,13 +535,13 @@ public final class MumblingTopicHelper {
                     : "worker";
             String needed = collectNeededItems(data);
             if (!needed.isEmpty()) {
-                return format(playerName, pick(
+                return format(playerName, MiscUtil.pick(
                         "You're completely stuck and can't do your work as a " + jobName + ". You need: " + needed + ". Call out to %s by name and urgently explain you're blocked and need help.",
                         "You can't continue your job as a " + jobName + " because you're missing something important: " + needed + ". Call out to %s by name and ask for assistance.",
                         "As a " + jobName + ", you're stuck waiting for supplies: " + needed + ". Call out to %s by name and plead for help to get back to work."
                 ));
             } else {
-                return format(playerName, pick(
+                return format(playerName, MiscUtil.pick(
                         "You're completely stuck and can't do your work as a " + jobName + ". Call out to %s by name and urgently explain what's wrong and ask for help.",
                         "You can't continue your job as a " + jobName + " because you're blocked by missing supplies. Call out to %s by name and ask for assistance."
                 ));
@@ -555,7 +550,7 @@ public final class MumblingTopicHelper {
 
         // ── CRITICAL: sickness ───────────────────────────
         if (data.getCitizenDiseaseHandler().isSick()) {
-            return format(playerName, pick(
+            return format(playerName, MiscUtil.pick(
                     "You are sick and feel terrible. Call out to %s by name and urgently ask for medicine or help.",
                     "You feel awful and can't ignore it anymore. Call out to %s by name and beg for help.",
                     "You're getting worse. Call out to %s by name and urgently ask for treatment."
@@ -565,7 +560,7 @@ public final class MumblingTopicHelper {
         // ── CRITICAL: starvation ─────────────────────────
         double saturation = data.getSaturation();
         if (saturation <= 1) {
-            return format(playerName, pick(
+            return format(playerName, MiscUtil.pick(
                     "You are starving and weak. Call out to %s by name and beg for food.",
                     "You can barely keep going from hunger. Call out to %s by name for something to eat.",
                     "You're desperate for food. Call out to %s by name and plead for help."
@@ -574,7 +569,7 @@ public final class MumblingTopicHelper {
 
         // ── CRITICAL: no home ────────────────────────────
         if (data.getHomeBuilding() == null && !CitizenHelper.isCitizenGuard(citizen)) {
-            return format(playerName, pick(
+            return format(playerName, MiscUtil.pick(
                     "You have nowhere to sleep. Call out to %s by name and urgently ask for help.",
                     "You're distressed about having no home. Call out to %s by name and plead for shelter.",
                     "You can't keep going like this without a place to rest. Call out to %s by name."
@@ -584,7 +579,7 @@ public final class MumblingTopicHelper {
         // ── LOW HAPPINESS ────────────────────────────────
         double happiness = data.getCitizenHappinessHandler().getHappiness(data.getColony(), data);
         if (happiness < 3.0) {
-            return format(playerName, pick(
+            return format(playerName, MiscUtil.pick(
                     "You're miserable and can't hold it in anymore. Call out to %s by name and voice your frustration.",
                     "You've had enough. Call out to %s by name and demand something change.",
                     "You're deeply unhappy. Call out to %s by name and explain what's wrong."
@@ -597,7 +592,7 @@ public final class MumblingTopicHelper {
             double healthPercent = (entity.get().getHealth() / Math.max(1.0, entity.get().getMaxHealth())) * 100.0;
 
             if (healthPercent < 25.0) {
-                return format(playerName, pick(
+                return format(playerName, MiscUtil.pick(
                         "You're badly injured and in pain. Call out to %s by name and ask for help.",
                         "You're struggling to stay on your feet. Call out to %s by name urgently.",
                         "You're hurt and need help. Call out to %s by name right now."


### PR DESCRIPTION
Closes #74

## Summary

The happiness modifier descriptions in citizen prompts were too generic and often inaccurate. This PR rewrites the prompt generation to reflect actual Minecolonies happiness mechanics with randomized, severity-aware messages.

## Key Changes

### `MiscUtil.java`
- Added `public static String pick(String... options)` — consolidates duplicated logic from `ColonyStatsHelper` and `MumblingTopicHelper`.

### `ColonyStatsHelper.java` & `MumblingTopicHelper.java`
- Both now delegate to `MiscUtil.pick()` instead of their own private implementations.

### `DefaultCitizenPromptProvider.java` — `appendDetailedHappinessState()`
Complete rewrite with:

- **Per-modifier severity tiers**: Each modifier has mild/severe sub-tiers based on factor deviation from 1.0
- **`pick()`-based randomization**: 3-4 variant messages per tier, selected randomly each time
- **Fixed dead branches**: `MYSTICAL_SITE < 0.8` (factor always ≥ 1.0), `SOCIAL > 1.2` (max 1.0) removed
- **Added missing branches**: `HOMELESSNESS > 1.2` (proud of home), `UNEMPLOYMENT > 1.2` (proud of high-level job)
- **FOOD accuracy**: References food diversity, quality, vanilla nutrition nerf (25%), and Minecolonies food tiers (1/2/3)
- **SLEPTTONIGHT threshold**: Lowered from 0.8 to 0.85 to include day-2 sleep deprivation (Minecolonies factor drops to 0.8)

### Modifier Details Table

| Modifier | Before | After |
|----------|--------|-------|
| FOOD | Single line: "Unhappy with food quality/variety" | 4 tiers with 3 variants each, referencing diversity/quality/tiers |
| HOMELESSNESS | "Distressed about housing" | 2 negative tiers + positive branch (proud of home) |
| UNEMPLOYMENT | "Anxious about employment" | 2 negative tiers + positive branch (proud of job) |
| SLEPTTONIGHT | "Tired from lack of sleep" | threshold 0.85, 2 tiers (tired/exhausted) |
| MYSTICAL_SITE | Had dead negative branch | Only positive (> 1.2), 3 variants |
| SOCIAL | Had dead positive branch | Only negative (< 0.8), 2 severity tiers |

## Testing
- Build: ✅ `BUILD SUCCESSFUL`
- Tests: ✅ All passing