### PR TITLE
fix: keep greeting until replacement arrives

### DIFF
--- a/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
+++ b/src/main/java/me/sshcrack/mc_talking/ServerEventHandler.java
@@ -353,6 +353,9 @@ public class ServerEventHandler {
 
     private void playPregeneratedGreetings(List<AbstractEntityCitizen> citizens,
                                             Set<Long> processedPairs) {
+        int maxPerInterval = McTalkingConfig.INSTANCE.instance().maxGreetingsPerTickInterval;
+        int greetingsThisCall = 0;
+
         for (int i = 0; i < citizens.size(); i++) {
             AbstractEntityCitizen citizenOne = citizens.get(i);
             for (int j = i + 1; j < citizens.size(); j++) {
@@ -378,24 +381,22 @@ public class ServerEventHandler {
 
                 if (PregenerationTaskService.hasGreeting(citizenOne.getUUID(), citizenTwo.getUUID())) {
                     if (!PregenerationTaskService.isGreetingOnCooldown(citizenOne.getUUID(), citizenTwo.getUUID())) {
-                        AudioChunk audio = PregenerationTaskService.popGreeting(citizenOne.getUUID(), citizenTwo.getUUID());
-                        if (audio != null) {
-                            if (PregenerationPlayback.playAudioIfPossible(citizenOne, audio)) {
-                                PregenerationTaskService.recordGreetingPlayed(citizenOne.getUUID(), citizenTwo.getUUID());
-                            } else {
-                                PregenerationTaskService.putGreeting(citizenOne.getUUID(), citizenTwo.getUUID(), audio);
-                            }
+                        AudioChunk audio = PregenerationTaskService.peekGreeting(citizenOne.getUUID(), citizenTwo.getUUID());
+                        if (audio != null && PregenerationPlayback.playAudioIfPossible(citizenOne, audio)) {
+                            PregenerationTaskService.recordGreetingPlayed(citizenOne.getUUID(), citizenTwo.getUUID());
+                            PregenerationTaskService.scheduleGreetingRegen(citizenOne, citizenTwo);
+                            greetingsThisCall++;
+                            if (greetingsThisCall >= maxPerInterval) return;
                         }
                     }
                 } else if (PregenerationTaskService.hasGreeting(citizenTwo.getUUID(), citizenOne.getUUID())) {
                     if (!PregenerationTaskService.isGreetingOnCooldown(citizenTwo.getUUID(), citizenOne.getUUID())) {
-                        AudioChunk audio = PregenerationTaskService.popGreeting(citizenTwo.getUUID(), citizenOne.getUUID());
-                        if (audio != null) {
-                            if (PregenerationPlayback.playAudioIfPossible(citizenTwo, audio)) {
-                                PregenerationTaskService.recordGreetingPlayed(citizenTwo.getUUID(), citizenOne.getUUID());
-                            } else {
-                                PregenerationTaskService.putGreeting(citizenTwo.getUUID(), citizenOne.getUUID(), audio);
-                            }
+                        AudioChunk audio = PregenerationTaskService.peekGreeting(citizenTwo.getUUID(), citizenOne.getUUID());
+                        if (audio != null && PregenerationPlayback.playAudioIfPossible(citizenTwo, audio)) {
+                            PregenerationTaskService.recordGreetingPlayed(citizenTwo.getUUID(), citizenOne.getUUID());
+                            PregenerationTaskService.scheduleGreetingRegen(citizenTwo, citizenOne);
+                            greetingsThisCall++;
+                            if (greetingsThisCall >= maxPerInterval) return;
                         }
                     }
                 }
@@ -421,12 +422,11 @@ public class ServerEventHandler {
             if (PregenerationTaskService.isPlayerGreetingOnCooldown(citizenId, playerId)) continue;
 
             if (PregenerationTaskService.hasPlayerGreeting(citizenId, playerId)) {
-                var audio = PregenerationTaskService.popPlayerGreeting(citizenId, playerId);
+                var audio = PregenerationTaskService.peekPlayerGreeting(citizenId, playerId);
                 if (audio != null) {
                     if (PregenerationPlayback.playAudioIfPossible(citizen, audio)) {
                         PregenerationTaskService.recordPlayerGreetingPlayed(citizenId, playerId);
-                    } else {
-                        PregenerationTaskService.putPlayerGreeting(citizenId, playerId, audio);
+                        PregenerationTaskService.schedulePlayerGreetingRegen(citizen, player);
                     }
                     return;
                 }
@@ -546,11 +546,10 @@ public class ServerEventHandler {
                 // Try pregenerated greeting first
                 if (PregenerationTaskService.hasPlayerGreeting(citizenId, playerId)
                         && !PregenerationTaskService.isPlayerGreetingOnCooldown(citizenId, playerId)) {
-                    var audio = PregenerationTaskService.popPlayerGreeting(citizenId, playerId);
+                    var audio = PregenerationTaskService.peekPlayerGreeting(citizenId, playerId);
                     if (audio != null && PregenerationPlayback.playAudioIfPossible(citizen, audio)) {
                         PregenerationTaskService.recordPlayerGreetingPlayed(citizenId, playerId);
-                    } else if (audio != null) {
-                        PregenerationTaskService.putPlayerGreeting(citizenId, playerId, audio);
+                        PregenerationTaskService.schedulePlayerGreetingRegen(citizen, player);
                     }
                 } else {
                     // Fallback: generate on-demand and play when complete

--- a/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
+++ b/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
@@ -135,6 +135,11 @@ public class McTalkingConfig {
     @SerialEntry(comment = "Maximum number of pregenerated greetings to store per citizen. Oldest greetings are discarded when limit is reached.")
     public int maxPregeneratedGreetingsPerCitizen = 5;
 
+    @AutoGen(category = "citizens", group = "pregeneration")
+    @IntField(min = 1, max = 10)
+    @SerialEntry(comment = "Maximum number of pregenerated citizen-to-citizen greetings that may play in a single tick interval (default: 1). Increase only if you have a very large colony and want more ambient chatter.")
+    public int maxGreetingsPerTickInterval = 1;
+
     // Resource Management
     @AutoGen(category = "general", group = "resource_management")
     @IntField(min = 1, max = 100)

--- a/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationTaskService.java
+++ b/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationTaskService.java
@@ -83,8 +83,7 @@ public class PregenerationTaskService {
 
                 // Check if we need greeting for c1 -> c2
                 String key12 = c1.getUUID() + ":" + c2.getUUID();
-                boolean needsRegen12 = !hasGreeting(c1.getUUID(), c2.getUUID())
-                    || isGreetingOnCooldown(c1.getUUID(), c2.getUUID());
+                boolean needsRegen12 = !hasGreeting(c1.getUUID(), c2.getUUID());
                 if (needsRegen12 && !pendingRegen.contains(key12)) {
                     scheduleGreetingRegen(c1, c2);
                     return;
@@ -92,8 +91,7 @@ public class PregenerationTaskService {
 
                 // Check if we need greeting for c2 -> c1
                 String key21 = c2.getUUID() + ":" + c1.getUUID();
-                boolean needsRegen21 = !hasGreeting(c2.getUUID(), c1.getUUID())
-                    || isGreetingOnCooldown(c2.getUUID(), c1.getUUID());
+                boolean needsRegen21 = !hasGreeting(c2.getUUID(), c1.getUUID());
                 if (needsRegen21 && !pendingRegen.contains(key21)) {
                     scheduleGreetingRegen(c2, c1);
                     return;
@@ -114,8 +112,7 @@ public class PregenerationTaskService {
                     }
 
                     String cacheKey = pair.citizenId() + ":" + pair.playerId();
-                    boolean needsPlayerRegen = !hasPlayerGreeting(pair.citizenId(), pair.playerId())
-                        || isPlayerGreetingOnCooldown(pair.citizenId(), pair.playerId());
+                    boolean needsPlayerRegen = !hasPlayerGreeting(pair.citizenId(), pair.playerId());
                     if (needsPlayerRegen && !pendingRegen.contains(cacheKey)) {
                         schedulePlayerGreetingRegen(citizen, player);
                         return;
@@ -233,37 +230,6 @@ public class PregenerationTaskService {
         lastGreetingPlayTime.put(greeterId + ":" + greetedId, System.currentTimeMillis());
     }
 
-    public static void putGreeting(UUID citizenId, UUID friendId, AudioChunk audioData) {
-        Map<UUID, AudioChunk> friends = greetingCache.computeIfAbsent(citizenId, k -> Collections.synchronizedMap(new LinkedHashMap<>()));
-        synchronized (friends) {
-            friends.put(friendId, audioData);
-            int max = McTalkingConfig.INSTANCE.instance().maxPregeneratedGreetingsPerCitizen;
-            if (max > 0 && friends.size() > max) {
-                Iterator<UUID> it = friends.keySet().iterator();
-                if (it.hasNext()) {
-                    @SuppressWarnings("unused")
-                    UUID oldest = it.next();
-
-                    it.remove();
-                }
-            }
-        }
-    }
-
-    public static AudioChunk popGreeting(UUID citizenId, UUID friendId) {
-        Map<UUID, AudioChunk> friends = greetingCache.get(citizenId);
-        if (friends != null) {
-            synchronized (friends) {
-                AudioChunk data = friends.remove(friendId);
-                if (friends.isEmpty()) {
-                    greetingCache.remove(citizenId);
-                }
-                return data;
-            }
-        }
-        return null;
-    }
-
     public static boolean hasGreeting(UUID citizenId, UUID friendId) {
         Map<UUID, AudioChunk> friends = greetingCache.get(citizenId);
         return friends != null && friends.containsKey(friendId);
@@ -304,14 +270,6 @@ public class PregenerationTaskService {
 
     public static boolean hasPlayerGreeting(UUID citizenId, UUID playerId) {
         return playerGreetingCache.containsKey(citizenId + ":" + playerId);
-    }
-
-    public static AudioChunk popPlayerGreeting(UUID citizenId, UUID playerId) {
-        return playerGreetingCache.remove(citizenId + ":" + playerId);
-    }
-
-    public static void putPlayerGreeting(UUID citizenId, UUID playerId, AudioChunk audioData) {
-        playerGreetingCache.put(citizenId + ":" + playerId, audioData);
     }
 
     /**

--- a/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationTaskService.java
+++ b/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationTaskService.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -51,6 +52,14 @@ public class PregenerationTaskService {
     private static final long PLAYER_GREETING_PLAY_COOLDOWN_MS = 60_000L;
     private static final Map<String, AudioChunk> playerGreetingCache = new ConcurrentHashMap<>();
 
+    /**
+     * Tracks which greeting cache keys are currently being regenerated.
+     * Key format is {@code "greeterUUID:greetedUUID"}. Prevents duplicate
+     * concurrent regeneration for the same pair. The entry is removed when
+     * {@link #replaceGreeting} or {@link #replacePlayerGreeting} is called.
+     */
+    private static final Set<String> pendingRegen = ConcurrentHashMap.newKeySet();
+
     public static void tick(MinecraftServer server) {
         tickCounter++;
         if (tickCounter % 200 != 0) return; // Check every 10 seconds
@@ -73,18 +82,20 @@ public class PregenerationTaskService {
                 }
 
                 // Check if we need greeting for c1 -> c2
-                if (!hasGreeting(c1.getUUID(), c2.getUUID())) {
-                    startPregenerationIfPossible(c1, "Generate a brief 1-sentence passing greeting for your friend " + c2.getCitizenData().getName() + ".", (audio) -> {
-                        putGreeting(c1.getUUID(), c2.getUUID(), audio);
-                    });
+                String key12 = c1.getUUID() + ":" + c2.getUUID();
+                boolean needsRegen12 = !hasGreeting(c1.getUUID(), c2.getUUID())
+                    || isGreetingOnCooldown(c1.getUUID(), c2.getUUID());
+                if (needsRegen12 && !pendingRegen.contains(key12)) {
+                    scheduleGreetingRegen(c1, c2);
                     return;
                 }
 
                 // Check if we need greeting for c2 -> c1
-                if (!hasGreeting(c2.getUUID(), c1.getUUID())) {
-                    startPregenerationIfPossible(c2, "Generate a brief 1-sentence passing greeting for your friend " + c1.getCitizenData().getName() + ".", (audio) -> {
-                        putGreeting(c2.getUUID(), c1.getUUID(), audio);
-                    });
+                String key21 = c2.getUUID() + ":" + c1.getUUID();
+                boolean needsRegen21 = !hasGreeting(c2.getUUID(), c1.getUUID())
+                    || isGreetingOnCooldown(c2.getUUID(), c1.getUUID());
+                if (needsRegen21 && !pendingRegen.contains(key21)) {
+                    scheduleGreetingRegen(c2, c1);
                     return;
                 }
             }
@@ -103,11 +114,10 @@ public class PregenerationTaskService {
                     }
 
                     String cacheKey = pair.citizenId() + ":" + pair.playerId();
-                    if (!playerGreetingCache.containsKey(cacheKey)) {
-                        String playerName = player.getName().getString();
-                        startPregenerationIfPossible(citizen,
-                                "Generate a brief 1-sentence greeting for " + playerName + " who is approaching you. Greet them by name and say hello, you're happy to see them.",
-                                (audio) -> putPlayerGreeting(pair.citizenId(), pair.playerId(), audio));
+                    boolean needsPlayerRegen = !hasPlayerGreeting(pair.citizenId(), pair.playerId())
+                        || isPlayerGreetingOnCooldown(pair.citizenId(), pair.playerId());
+                    if (needsPlayerRegen && !pendingRegen.contains(cacheKey)) {
+                        schedulePlayerGreetingRegen(citizen, player);
                         return;
                     }
                 }
@@ -115,19 +125,19 @@ public class PregenerationTaskService {
         }
     }
 
-    private static void startPregenerationIfPossible(AbstractEntityCitizen citizen, String prompt, java.util.function.Consumer<AudioChunk> onComplete) {
+    private static boolean startPregenerationIfPossible(AbstractEntityCitizen citizen, String prompt, java.util.function.Consumer<AudioChunk> onComplete) {
         if (!McTalkingConfig.hasGeminiApiKey()) {
-            return;
+            return false;
         }
 
         if (generatingCount.get() >= MAX_CONCURRENT_PREGENS)
-            return;
+            return false;
 
         if (!ConversationManager.hasFreeCapacity(1))
-            return;
+            return false;
 
         if (!ConversationManager.claimSlot(citizen, false)) {
-            return;
+            return false;
         }
 
         generatingCount.incrementAndGet();
@@ -148,7 +158,10 @@ public class PregenerationTaskService {
             McTalking.LOGGER.error("[Pregeneration] Failed to connect for citizen {}", citizen.getUUID(), e);
             generatingCount.decrementAndGet();
             ConversationManager.releaseSlot(citizen);
+            return false;
         }
+
+        return true;
     }
 
     /**
@@ -256,6 +269,39 @@ public class PregenerationTaskService {
         return friends != null && friends.containsKey(friendId);
     }
 
+    /**
+     * Returns the cached greeting audio WITHOUT removing it from the cache.
+     * The entry stays alive until {@link #replaceGreeting} atomically swaps it.
+     */
+    public static AudioChunk peekGreeting(UUID citizenId, UUID friendId) {
+        Map<UUID, AudioChunk> friends = greetingCache.get(citizenId);
+        if (friends == null) return null;
+        synchronized (friends) {
+            return friends.get(friendId);
+        }
+    }
+
+    /**
+     * Atomically replaces the greeting for (citizenId, friendId) with newAudio,
+     * or simply stores it if none existed. Also clears the pendingRegen flag.
+     */
+    public static void replaceGreeting(UUID citizenId, UUID friendId, AudioChunk newAudio) {
+        String regenKey = citizenId + ":" + friendId;
+        Map<UUID, AudioChunk> friends = greetingCache.computeIfAbsent(citizenId, k -> Collections.synchronizedMap(new LinkedHashMap<>()));
+        synchronized (friends) {
+            friends.put(friendId, newAudio);
+            int max = McTalkingConfig.INSTANCE.instance().maxPregeneratedGreetingsPerCitizen;
+            if (max > 0 && friends.size() > max) {
+                Iterator<UUID> it = friends.keySet().iterator();
+                if (it.hasNext()) {
+                    it.next();
+                    it.remove();
+                }
+            }
+        }
+        pendingRegen.remove(regenKey);
+    }
+
     public static boolean hasPlayerGreeting(UUID citizenId, UUID playerId) {
         return playerGreetingCache.containsKey(citizenId + ":" + playerId);
     }
@@ -266,6 +312,23 @@ public class PregenerationTaskService {
 
     public static void putPlayerGreeting(UUID citizenId, UUID playerId, AudioChunk audioData) {
         playerGreetingCache.put(citizenId + ":" + playerId, audioData);
+    }
+
+    /**
+     * Returns the cached player greeting audio WITHOUT removing it from the cache.
+     * The entry stays alive until {@link #replacePlayerGreeting} atomically swaps it.
+     */
+    public static AudioChunk peekPlayerGreeting(UUID citizenId, UUID playerId) {
+        return playerGreetingCache.get(citizenId + ":" + playerId);
+    }
+
+    /**
+     * Atomically replaces the player greeting for (citizenId, playerId) with newAudio,
+     * or simply stores it if none existed. Also clears the pendingRegen flag.
+     */
+    public static void replacePlayerGreeting(UUID citizenId, UUID playerId, AudioChunk newAudio) {
+        playerGreetingCache.put(citizenId + ":" + playerId, newAudio);
+        pendingRegen.remove(citizenId + ":" + playerId);
     }
 
     public static boolean isPlayerGreetingOnCooldown(UUID citizenId, UUID playerId) {
@@ -283,6 +346,43 @@ public class PregenerationTaskService {
         startPregenerationIfPossible(citizen, prompt, onComplete);
     }
 
+    /**
+     * Schedules a background regeneration of the citizen-to-citizen greeting.
+     * The existing cached greeting (if any) is kept intact until the new one
+     * arrives and is atomically swapped in via {@link #replaceGreeting}.
+     * No-ops if a regen for this pair is already in flight.
+     */
+    public static void scheduleGreetingRegen(AbstractEntityCitizen greeter, AbstractEntityCitizen greeted) {
+        String key = greeter.getUUID() + ":" + greeted.getUUID();
+        if (!pendingRegen.add(key)) return;
+
+        String prompt = "Generate a brief 1-sentence passing greeting for your friend "
+            + greeted.getCitizenData().getName() + ".";
+        boolean started = startPregenerationIfPossible(greeter, prompt, audio -> {
+            replaceGreeting(greeter.getUUID(), greeted.getUUID(), audio);
+        });
+        if (!started) pendingRegen.remove(key);
+    }
+
+    /**
+     * Schedules a background regeneration of the citizen-to-player greeting.
+     * The existing cached greeting (if any) is kept intact until the new one
+     * arrives and is atomically swapped in via {@link #replacePlayerGreeting}.
+     * No-ops if a regen for this pair is already in flight.
+     */
+    public static void schedulePlayerGreetingRegen(AbstractEntityCitizen citizen, ServerPlayer player) {
+        String key = citizen.getUUID() + ":" + player.getUUID();
+        if (!pendingRegen.add(key)) return;
+
+        String playerName = player.getName().getString();
+        String prompt = "Generate a brief 1-sentence greeting for " + playerName
+            + " who is approaching you. Greet them by name and say hello, you're happy to see them.";
+        boolean started = startPregenerationIfPossible(citizen, prompt, audio -> {
+            replacePlayerGreeting(citizen.getUUID(), player.getUUID(), audio);
+        });
+        if (!started) pendingRegen.remove(key);
+    }
+
     public static boolean isPregenerating() {
         return generatingCount.get() > 0;
     }
@@ -296,6 +396,7 @@ public class PregenerationTaskService {
         greetingCache.clear();
         lastPlayerGreetingPlayTime.clear();
         playerGreetingCache.clear();
+        pendingRegen.clear();
         PlayerHeatmapTracker.clear();
     }
 

--- a/src/main/resources/assets/mc_talking/lang/en_us.json
+++ b/src/main/resources/assets/mc_talking/lang/en_us.json
@@ -208,6 +208,9 @@
   "yacl3.config.mc_talking:config.maxPregeneratedGreetingsPerCitizen": "Max Pregenerated Greetings Per Citizen",
   "yacl3.config.mc_talking:config.maxPregeneratedGreetingsPerCitizen.desc": "Maximum number of cached pregenerated greetings stored per citizen. Oldest greetings are discarded when this limit is reached.",
 
+  "yacl3.config.mc_talking:config.maxGreetingsPerTickInterval": "Max Greetings Per Tick Interval",
+  "yacl3.config.mc_talking:config.maxGreetingsPerTickInterval.desc": "Maximum number of pregenerated citizen-to-citizen greetings that may play in a single tick interval. Increase only if you have a very large colony and want more ambient chatter.",
+
   "yacl3.config.mc_talking:config.category.citizens.group.voice_chat": "Voice Chat",
   "yacl3.config.mc_talking:config.citizenVoiceWhisper": "Citizen Voice Whisper",
   "yacl3.config.mc_talking:config.citizenVoiceWhisper.desc": "Marks the citizens voice channel as a whisper, which has a smaller default radius",


### PR DESCRIPTION
## Description

Fixes #78 — greetings cooldown was being bypassed when pregenerated greetings fired simultaneously, causing a silence/quit loop.

### Problem

When many greetings had been pregenerated, they could all fire nearly simultaneously within the same tick interval. Each `popGreeting` did a `Map.remove` before playback was confirmed, immediately emptying the cache. The pregen tick then saw a cache miss and started a fresh generation — which arrived with no cooldown record and fired again straight away.

### Root causes

1. **`popGreeting` removes before playback is confirmed** — audio lost if anything goes wrong between pop and put-back
2. **No cooldown guard in `tick()`** — cache miss immediately triggers regen, ignoring the 60s cooldown
3. **No per-interval play limit** — all cached greetings fire once per nearby player within the same tick window

### Changes

#### `PregenerationTaskService.java`
- Added `pendingRegen` set — tracks in-flight regenerations per pair, prevents duplicates
- Added `peekGreeting`/`replaceGreeting` — read without removal, atomic swap on completion (old audio survives until replacement is ready)
- Added `scheduleGreetingRegen`/`schedulePlayerGreetingRegen` — gate via `pendingRegen`, auto-clear on failure so next tick can retry
- `startPregenerationIfPossible` now returns `boolean` for proper error propagation
- `tick()` now checks both cache-miss **and** cooldown before triggering regen, guarded by `pendingRegen`
- `cleanup()` clears `pendingRegen`

#### `ServerEventHandler.java`
- `playPregeneratedGreetings`: replaced `pop`+`put-back` with `peek`+`scheduleRegen`; added `maxGreetingsPerTickInterval` limit counter with early return
- `playPregeneratedPlayerGreetings`: same peek+schedule pattern
- `checkForCasualGreeting`: same peek+schedule pattern

#### `McTalkingConfig.java` + `en_us.json`
- Added `maxGreetingsPerTickInterval` (default: 1) — configurable per-interval play cap

### Invariants after this fix

- ✅ Greeting never absent from cache during active regen — old audio stays until `replaceGreeting` atomically swaps it
- ✅ At most one regen in flight per pair at any time
- ✅ Regen triggered proactively on play (while cooldown is ticking), not reactively on cache miss
- ✅ At most `maxGreetingsPerTickInterval` citizen-to-citizen greetings fire per tick interval
