### PR TITLE
Use gemini-live-2.5-flash-native-audio for memory compaction and pregeneration

### DIFF
--- a/src/main/java/me/sshcrack/mc_talking/ConversationManager.java
+++ b/src/main/java/me/sshcrack/mc_talking/ConversationManager.java
@@ -12,6 +12,7 @@ import me.sshcrack.mc_talking.manager.GeminiWsClient;
 import me.sshcrack.mc_talking.manager.audio.CitzienEntityAudioProvider;
 import me.sshcrack.mc_talking.network.AiStatus;
 import me.sshcrack.mc_talking.util.AiStatusHelper;
+import me.sshcrack.mc_talking.util.BackgroundSlotType;
 import me.sshcrack.mc_talking.util.MumblingTopicHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -117,7 +118,7 @@ public class ConversationManager {
 
     // ---- Background pool (flash2.5 model) ----
     private static final Set<UUID> backgroundSlots = new LinkedHashSet<>();
-    private static final Map<UUID, String> backgroundSlotTypes = new ConcurrentHashMap<>();
+    private static final Map<UUID, BackgroundSlotType> backgroundSlotTypes = new ConcurrentHashMap<>();
     private static final Map<UUID, GeminiLiveClient> backgroundClients = new ConcurrentHashMap<>();
 
     // -------------------------------------------------------------------------
@@ -235,11 +236,22 @@ public class ConversationManager {
     // ---- Background pool methods ----
 
     public static synchronized boolean hasFreeBackgroundCapacity(int slotsNeeded) {
+        purgeStaleBackgroundSlots();
         int max = McTalkingConfig.INSTANCE.instance().maxConcurrentBackground;
         return (max - backgroundSlots.size()) >= slotsNeeded;
     }
 
-    public static synchronized boolean claimBackgroundSlot(AbstractEntityCitizen citizen, String type) {
+    public static synchronized int getUsedBackgroundSlots() {
+        return backgroundSlots.size();
+    }
+
+    public static synchronized int getMaxBackgroundSlots() {
+        return McTalkingConfig.INSTANCE.instance().maxConcurrentBackground;
+    }
+
+    public static synchronized boolean claimBackgroundSlot(AbstractEntityCitizen citizen, BackgroundSlotType type) {
+        purgeStaleBackgroundSlots();
+
         UUID id = citizen.getUUID();
         if (backgroundSlots.contains(id)) return true;
 
@@ -252,10 +264,10 @@ public class ConversationManager {
             return true;
         }
 
-        if ("compaction".equals(type)) {
+        if (type == BackgroundSlotType.COMPACTION) {
             UUID victim = null;
             for (UUID candidate : backgroundSlots) {
-                if ("pregen".equals(backgroundSlotTypes.get(candidate))) {
+                if (backgroundSlotTypes.get(candidate) == BackgroundSlotType.PREGEN) {
                     victim = candidate;
                     break;
                 }
@@ -275,11 +287,29 @@ public class ConversationManager {
     public static synchronized void releaseBackgroundSlot(UUID entityId) {
         backgroundSlots.remove(entityId);
         backgroundSlotTypes.remove(entityId);
-        backgroundClients.remove(entityId);
+        GeminiLiveClient client = backgroundClients.remove(entityId);
+        if (client != null) {
+            try { client.close(); } catch (Exception e) {
+                McTalking.LOGGER.warn("[ConversationManager] Error closing released bg client {}", entityId, e);
+            }
+        }
     }
 
     public static synchronized void registerBackgroundClient(UUID entityId, GeminiLiveClient client) {
         backgroundClients.put(entityId, client);
+    }
+
+    private static void purgeStaleBackgroundSlots() {
+        var stale = backgroundClients.entrySet().stream()
+                .filter(e -> e.getValue().isClosed())
+                .map(Map.Entry::getKey)
+                .toList();
+        for (UUID id : stale) {
+            McTalking.LOGGER.info("[ConversationManager] Purging stale background slot for {}", id);
+            backgroundSlots.remove(id);
+            backgroundSlotTypes.remove(id);
+            backgroundClients.remove(id);
+        }
     }
 
     private static void evictBackgroundSlot(UUID entityId) {

--- a/src/main/java/me/sshcrack/mc_talking/ConversationManager.java
+++ b/src/main/java/me/sshcrack/mc_talking/ConversationManager.java
@@ -3,7 +3,9 @@ package me.sshcrack.mc_talking;
 import com.minecolonies.api.entity.ai.JobStatus;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.core.entity.visitor.VisitorCitizen;
+import me.sshcrack.gemini_live_lib.GeminiLiveClient;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
+import me.sshcrack.mc_talking.config.QuotaTracker;
 import me.sshcrack.mc_talking.item.CitizenTalkingDevice;
 import me.sshcrack.mc_talking.manager.CitizenWsClient;
 import me.sshcrack.mc_talking.manager.GeminiWsClient;
@@ -112,6 +114,11 @@ public class ConversationManager {
      * conversation) so a player conversation can take over.
      */
     private static final Map<UUID, Runnable> abortHandlers = new ConcurrentHashMap<>();
+
+    // ---- Background pool (flash2.5 model) ----
+    private static final Set<UUID> backgroundSlots = new LinkedHashSet<>();
+    private static final Map<UUID, String> backgroundSlotTypes = new ConcurrentHashMap<>();
+    private static final Map<UUID, GeminiLiveClient> backgroundClients = new ConcurrentHashMap<>();
 
     // -------------------------------------------------------------------------
     // Slot management (priority-aware, synchronized)
@@ -223,6 +230,68 @@ public class ConversationManager {
         int max = McTalkingConfig.INSTANCE.instance().maxConcurrentAgents;
         int free = max - addedEntities.size();
         return free >= slotsNeeded;
+    }
+
+    // ---- Background pool methods ----
+
+    public static synchronized boolean hasFreeBackgroundCapacity(int slotsNeeded) {
+        int max = McTalkingConfig.INSTANCE.instance().maxConcurrentBackground;
+        return (max - backgroundSlots.size()) >= slotsNeeded;
+    }
+
+    public static synchronized boolean claimBackgroundSlot(AbstractEntityCitizen citizen, String type) {
+        UUID id = citizen.getUUID();
+        if (backgroundSlots.contains(id)) return true;
+
+        int max = McTalkingConfig.INSTANCE.instance().maxConcurrentBackground;
+
+        if (backgroundSlots.size() < max) {
+            backgroundSlots.add(id);
+            backgroundSlotTypes.put(id, type);
+            McTalking.LOGGER.info("[ConversationManager] Reserved background slot for {} (type={})", id, type);
+            return true;
+        }
+
+        if ("compaction".equals(type)) {
+            UUID victim = null;
+            for (UUID candidate : backgroundSlots) {
+                if ("pregen".equals(backgroundSlotTypes.get(candidate))) {
+                    victim = candidate;
+                    break;
+                }
+            }
+            if (victim != null) {
+                evictBackgroundSlot(victim);
+                backgroundSlots.add(id);
+                backgroundSlotTypes.put(id, type);
+                McTalking.LOGGER.info("[ConversationManager] Evicted pregen bg slot {} for compaction {}", victim, id);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static synchronized void releaseBackgroundSlot(UUID entityId) {
+        backgroundSlots.remove(entityId);
+        backgroundSlotTypes.remove(entityId);
+        backgroundClients.remove(entityId);
+    }
+
+    public static synchronized void registerBackgroundClient(UUID entityId, GeminiLiveClient client) {
+        backgroundClients.put(entityId, client);
+    }
+
+    private static void evictBackgroundSlot(UUID entityId) {
+        backgroundSlots.remove(entityId);
+        backgroundSlotTypes.remove(entityId);
+        GeminiLiveClient client = backgroundClients.remove(entityId);
+        if (client != null) {
+            try { client.close(); } catch (Exception e) {
+                McTalking.LOGGER.warn("[ConversationManager] Error closing evicted bg client {}", entityId, e);
+            }
+        }
+        McTalking.LOGGER.info("[ConversationManager] Evicted background slot for {}", entityId);
     }
 
     /**
@@ -343,7 +412,8 @@ public class ConversationManager {
      * Use this before starting any new session to avoid duplicates.
      */
     public static synchronized boolean isCitizenBusy(AbstractEntityCitizen citizen) {
-        return clients.containsKey(citizen.getUUID()) || addedEntities.contains(citizen.getUUID()) || busyEntities.contains(citizen.getUUID());
+        UUID id = citizen.getUUID();
+        return clients.containsKey(id) || addedEntities.contains(id) || busyEntities.contains(id) || backgroundSlots.contains(id);
     }
 
     /**
@@ -651,15 +721,22 @@ public class ConversationManager {
                 McTalking.LOGGER.error("Error closing client during cleanup", e);
             }
         }
+        for (GeminiLiveClient client : backgroundClients.values()) {
+            try { client.close(); } catch (Exception ignored) {}
+        }
         clients.clear();
         activeEntity.clear();
         playerConversationPartners.clear();
         citizenToPlayer.clear();
         addedEntities.clear();
+        backgroundSlots.clear();
+        backgroundSlotTypes.clear();
+        backgroundClients.clear();
         busyEntities.clear();
         abortHandlers.clear();
         lastSessionEndTime.clear();
         lastSessionNeedSignatures.clear();
+        QuotaTracker.clear();
         GeminiWsClient.shutdownExecutor();
     }
 }

--- a/src/main/java/me/sshcrack/mc_talking/commands/DebugCitizenCommand.java
+++ b/src/main/java/me/sshcrack/mc_talking/commands/DebugCitizenCommand.java
@@ -12,6 +12,7 @@ import me.sshcrack.mc_talking.duck.CitizenDataMemoryExtended;
 import me.sshcrack.mc_talking.duck.CitizenDataPersonalityExtended;
 import me.sshcrack.mc_talking.manager.GeminiWsClient;
 import me.sshcrack.mc_talking.network.AiStatus;
+import me.sshcrack.mc_talking.pregen.PregenerationTaskService;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -121,6 +122,10 @@ public class DebugCitizenCommand {
             msg.append(field("isChild", String.valueOf(data.isChild())));
             msg.append(field("isSick", String.valueOf(data.getCitizenDiseaseHandler().isSick())));
             msg.append(field("isHomeless", String.valueOf(data.getHomeBuilding() == null)));
+
+            int greetingCount = PregenerationTaskService.getGreetingCount(citizenId);
+            int playerGreetingCount = PregenerationTaskService.getPlayerGreetingCount(citizenId);
+            msg.append(field("Greetings", greetingCount + " citizen, " + playerGreetingCount + " player"));
 
             return msg;
         }, false);

--- a/src/main/java/me/sshcrack/mc_talking/commands/DebugStatusCommand.java
+++ b/src/main/java/me/sshcrack/mc_talking/commands/DebugStatusCommand.java
@@ -3,6 +3,7 @@ package me.sshcrack.mc_talking.commands;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import me.sshcrack.mc_talking.ConversationManager;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
+import me.sshcrack.mc_talking.config.QuotaTracker;
 import me.sshcrack.mc_talking.conversations.memory.MemoryCompactionService;
 import me.sshcrack.mc_talking.pregen.PregenerationTaskService;
 import net.minecraft.ChatFormatting;
@@ -90,6 +91,20 @@ public class DebugStatusCommand {
                             McTalkingDebugCommand.booleanToStr(config.enableMemoryCompaction),
                             config.memoryMode.name(),
                             MemoryCompactionService.getActiveCount()))
+                    .withStyle(ChatFormatting.GRAY)
+                    .append(Component.literal("\n"));
+
+            boolean liveQuotaExceeded = QuotaTracker.isQuotaExceeded(McTalkingConfig.CHEAP_LIVE_MODEL.getName());
+            msg.append(Component.literal("  "))
+                    .append(Component.translatable("mc_talking.debug.status_quota",
+                            liveQuotaExceeded ? "§cexceeded" : "§aok"))
+                    .withStyle(ChatFormatting.GRAY)
+                    .append(Component.literal("\n"));
+
+            int usedBg = ConversationManager.getUsedBackgroundSlots();
+            int maxBg = ConversationManager.getMaxBackgroundSlots();
+            msg.append(Component.literal("  "))
+                    .append(Component.translatable("mc_talking.debug.status_bg_slots", usedBg, maxBg))
                     .withStyle(ChatFormatting.GRAY);
 
             return msg;

--- a/src/main/java/me/sshcrack/mc_talking/config/AvailableAI.java
+++ b/src/main/java/me/sshcrack/mc_talking/config/AvailableAI.java
@@ -16,7 +16,7 @@ public enum AvailableAI implements NameableEnum {
             List.of("Zephyr", "Kore", "Leda", "Aoede", "Callirrhoe", "Autonoe", "Despina", "Erinome", "Laomedeia", "Achernar", "Gacrux", "Pulcherrima", "Vindemiatrix", "Sulafat")
     ),
     @SuppressWarnings("SpellCheckingInspection")
-    Flash2_5("gemini-live-2.5-flash-native-audio",
+    Flash2_5("gemini-2.5-flash-native-audio-preview-12-2025",
             List.of("Puck", "Charon", "Orus", "Enceladus", "Iapetus", "Umbriel", "Algieba", "Algenib", "Rasalgethi", "Alnilam", "Schedar", "Archid", "Zubenelgenubi", "Sadachbia", "Sadaltager"),
             List.of("Zephyr", "Kore", "Leda", "Aoede", "Callirrhoe", "Autonoe", "Despina", "Erinome", "Laomedeia", "Achernar", "Gacrux", "Pulcherrima", "Vindemiatrix", "Sulafat")
     );

--- a/src/main/java/me/sshcrack/mc_talking/config/AvailableAI.java
+++ b/src/main/java/me/sshcrack/mc_talking/config/AvailableAI.java
@@ -14,6 +14,11 @@ public enum AvailableAI implements NameableEnum {
     Flash3("gemini-3.1-flash-live-preview",
             List.of("Puck", "Charon", "Orus", "Enceladus", "Iapetus", "Umbriel", "Algieba", "Algenib", "Rasalgethi", "Alnilam", "Schedar", "Archid", "Zubenelgenubi", "Sadachbia", "Sadaltager"),
             List.of("Zephyr", "Kore", "Leda", "Aoede", "Callirrhoe", "Autonoe", "Despina", "Erinome", "Laomedeia", "Achernar", "Gacrux", "Pulcherrima", "Vindemiatrix", "Sulafat")
+    ),
+    @SuppressWarnings("SpellCheckingInspection")
+    Flash2_5("gemini-live-2.5-flash-native-audio",
+            List.of("Puck", "Charon", "Orus", "Enceladus", "Iapetus", "Umbriel", "Algieba", "Algenib", "Rasalgethi", "Alnilam", "Schedar", "Archid", "Zubenelgenubi", "Sadachbia", "Sadaltager"),
+            List.of("Zephyr", "Kore", "Leda", "Aoede", "Callirrhoe", "Autonoe", "Despina", "Erinome", "Laomedeia", "Achernar", "Gacrux", "Pulcherrima", "Vindemiatrix", "Sulafat")
     );
 
     private final String name;

--- a/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
+++ b/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
@@ -30,6 +30,7 @@ import java.util.List;
 public class McTalkingConfig {
     public static final String FLASH_MODEL = "gemini-flash-lite-latest";
     public static final String TTS_MODEL = "gemini-3.1-flash-tts-preview";
+    public static final String CHEAP_LIVE_MODEL = "gemini-live-2.5-flash-native-audio";
 
     /** Movement speed multiplier when a citizen walks to the player on urgent contact. */
     public static final double CITIZEN_URGENT_WALK_SPEED = 1.2;

--- a/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
+++ b/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class McTalkingConfig {
     public static final String FLASH_MODEL = "gemini-flash-lite-latest";
     public static final String TTS_MODEL = "gemini-3.1-flash-tts-preview";
-    public static final String CHEAP_LIVE_MODEL = "gemini-live-2.5-flash-native-audio";
+    public static final AvailableAI CHEAP_LIVE_MODEL = AvailableAI.Flash2_5;
 
     /** Movement speed multiplier when a citizen walks to the player on urgent contact. */
     public static final double CITIZEN_URGENT_WALK_SPEED = 1.2;
@@ -141,6 +141,11 @@ public class McTalkingConfig {
     @IntField(min = 1, max = 100)
     @SerialEntry(comment = "Maximum number of AI agents that can be activated at once (for free tier Flash2.0 this is limited to 3, for Flash2.5 to 1)")
     public int maxConcurrentAgents = 3;
+
+    @AutoGen(category = "general", group = "resource_management")
+    @IntField(min = 1, max = 10)
+    @SerialEntry(comment = "Maximum concurrent background connections for the flash2.5 cheap live model (memory compaction, greeting pregeneration). The API allows 3 concurrent connections.")
+    public int maxConcurrentBackground = 3;
 
     @AutoGen(category = "general", group = "interaction")
     @DoubleField(min = 1.0, max = 100.0)

--- a/src/main/java/me/sshcrack/mc_talking/config/QuotaTracker.java
+++ b/src/main/java/me/sshcrack/mc_talking/config/QuotaTracker.java
@@ -1,0 +1,29 @@
+package me.sshcrack.mc_talking.config;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class QuotaTracker {
+    private QuotaTracker() {}
+
+    private static final ConcurrentHashMap<String, Long> exceededAt = new ConcurrentHashMap<>();
+    // The quota is only the Tokens per minute, there are no daily / monthly limits
+    private static final long QUOTA_WINDOW_MS = 60_000L;
+
+    public static void reportQuotaExceeded(String modelName) {
+        exceededAt.put(modelName, System.currentTimeMillis());
+    }
+
+    public static boolean isQuotaExceeded(String modelName) {
+        Long ts = exceededAt.get(modelName);
+        if (ts == null) return false;
+        if (System.currentTimeMillis() - ts >= QUOTA_WINDOW_MS) {
+            exceededAt.remove(modelName);
+            return false;
+        }
+        return true;
+    }
+
+    public static void clear() {
+        exceededAt.clear();
+    }
+}

--- a/src/main/java/me/sshcrack/mc_talking/conversations/LiveConversationWsClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/conversations/LiveConversationWsClient.java
@@ -3,6 +3,7 @@ package me.sshcrack.mc_talking.conversations;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import me.sshcrack.mc_talking.McTalking;
 import me.sshcrack.mc_talking.api.prompt.CitizenPromptService;
+import me.sshcrack.mc_talking.config.McTalkingConfig;
 import me.sshcrack.mc_talking.config.ModalityModes;
 import me.sshcrack.mc_talking.manager.CitizenPromptViewFactory;
 import me.sshcrack.mc_talking.manager.GeminiWsClient;
@@ -150,6 +151,11 @@ public class LiveConversationWsClient extends GeminiWsClient {
     protected ServerPlayer resolveActivePlayer() {
         // No player involved in a citizen-to-citizen live conversation.
         return null;
+    }
+
+    @Override
+    protected String getModelName() {
+        return McTalkingConfig.INSTANCE.instance().currentAiModel.getName();
     }
 
     @Override

--- a/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionService.java
+++ b/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionService.java
@@ -7,6 +7,7 @@ import me.sshcrack.mc_talking.ConversationManager;
 import me.sshcrack.mc_talking.McTalking;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
 import me.sshcrack.mc_talking.config.MemoryMode;
+import me.sshcrack.mc_talking.config.QuotaTracker;
 import me.sshcrack.mc_talking.conversations.memory.data.CitizenMemories;
 import me.sshcrack.mc_talking.duck.CitizenDataMemoryExtended;
 import net.minecraft.server.MinecraftServer;
@@ -41,7 +42,6 @@ public class MemoryCompactionService {
         if (tickCounter % interval != 0) return;
         if (McTalkingConfig.INSTANCE.instance().enableConversationSummaryAndMemorize) return;
         if (!McTalkingConfig.INSTANCE.instance().enableMemoryCompaction) return;
-        if (!activeCompactionCitizens.isEmpty()) return;
 
         var candidate = findBestCandidate(server);
         if (candidate == null) return;
@@ -143,8 +143,8 @@ public class MemoryCompactionService {
     private static void startLiveCompaction(AbstractEntityCitizen citizen) {
         UUID citizenId = citizen.getUUID();
 
-        if (!ConversationManager.hasFreeCapacity(1)) return;
-        if (!ConversationManager.claimSlot(citizen, false)) return;
+        if (QuotaTracker.isQuotaExceeded(McTalkingConfig.CHEAP_LIVE_MODEL.getName())) return;
+        if (!ConversationManager.claimBackgroundSlot(citizen, "compaction")) return;
 
         activeCompactionCitizens.add(citizenId);
 
@@ -154,7 +154,7 @@ public class MemoryCompactionService {
         MemoryCompactionWsClient client = new MemoryCompactionWsClient(citizen, mem,
                 summary -> {
                     activeCompactionCitizens.remove(citizenId);
-                    ConversationManager.releaseSlot(citizen);
+                    ConversationManager.releaseBackgroundSlot(citizenId);
                     if (summary != null && !summary.isBlank()) {
                         var server = citizen.level().getServer();
                         if (server != null) {
@@ -164,16 +164,17 @@ public class MemoryCompactionService {
                 },
                 () -> {
                     activeCompactionCitizens.remove(citizenId);
-                    ConversationManager.releaseSlot(citizen);
+                    ConversationManager.releaseBackgroundSlot(citizenId);
                     McTalking.LOGGER.warn("[MemoryCompaction] Live compaction failed for citizen {}", citizen.getCitizenData().getName());
                 });
 
         try {
             client.connect();
+            ConversationManager.registerBackgroundClient(citizenId, client);
         } catch (Exception e) {
             McTalking.LOGGER.error("[MemoryCompaction] Failed to connect Live client for citizen {}", citizen.getCitizenData().getName(), e);
             activeCompactionCitizens.remove(citizenId);
-            ConversationManager.releaseSlot(citizen);
+            ConversationManager.releaseBackgroundSlot(citizenId);
         }
     }
 

--- a/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionService.java
+++ b/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionService.java
@@ -9,6 +9,7 @@ import me.sshcrack.mc_talking.config.McTalkingConfig;
 import me.sshcrack.mc_talking.config.MemoryMode;
 import me.sshcrack.mc_talking.config.QuotaTracker;
 import me.sshcrack.mc_talking.conversations.memory.data.CitizenMemories;
+import me.sshcrack.mc_talking.util.BackgroundSlotType;
 import me.sshcrack.mc_talking.duck.CitizenDataMemoryExtended;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -144,7 +145,7 @@ public class MemoryCompactionService {
         UUID citizenId = citizen.getUUID();
 
         if (QuotaTracker.isQuotaExceeded(McTalkingConfig.CHEAP_LIVE_MODEL.getName())) return;
-        if (!ConversationManager.claimBackgroundSlot(citizen, "compaction")) return;
+        if (!ConversationManager.claimBackgroundSlot(citizen, BackgroundSlotType.COMPACTION)) return;
 
         activeCompactionCitizens.add(citizenId);
 

--- a/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionWsClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionWsClient.java
@@ -9,6 +9,7 @@ import me.sshcrack.gemini_live_lib.gson.RealtimeInput;
 import me.sshcrack.mc_talking.McTalking;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
 import me.sshcrack.mc_talking.config.ModalityModes;
+import me.sshcrack.mc_talking.config.QuotaTracker;
 import me.sshcrack.mc_talking.conversations.memory.data.CitizenMemories;
 
 import java.util.function.Consumer;
@@ -32,7 +33,7 @@ public class MemoryCompactionWsClient extends GeminiLiveClient {
 
     @Override
     public BidiGenerateContentSetup getSetup() {
-        var setup = new BidiGenerateContentSetup("models/" + McTalkingConfig.CHEAP_LIVE_MODEL);
+        var setup = new BidiGenerateContentSetup("models/" + McTalkingConfig.CHEAP_LIVE_MODEL.getName());
 
         setup.generationConfig.responseModalities = ModalityModes.TEXT_AND_AUDIO.getModalities();
         setup.outputAudioTranscription = new JsonObject();
@@ -45,7 +46,7 @@ public class MemoryCompactionWsClient extends GeminiLiveClient {
             var uuid = citizen.getUUID();
             setup.generationConfig.speechConfig.voice_config = new BidiGenerateContentSetup.GenerationConfig.SpeechConfig.VoiceConfig();
             setup.generationConfig.speechConfig.voice_config.prebuiltVoiceConfig = new BidiGenerateContentSetup.GenerationConfig.SpeechConfig.PrebuiltVoiceConfig();
-            setup.generationConfig.speechConfig.voice_config.prebuiltVoiceConfig.voice_name = McTalkingConfig.INSTANCE.instance().currentAiModel.getRandomVoice(uuid, female);
+            setup.generationConfig.speechConfig.voice_config.prebuiltVoiceConfig.voice_name = McTalkingConfig.CHEAP_LIVE_MODEL.getRandomVoice(uuid, female);
         }
 
         setup.realtimeInputConfig = new BidiGenerateContentSetup.RealtimeInputConfig();
@@ -104,6 +105,7 @@ public class MemoryCompactionWsClient extends GeminiLiveClient {
     @Override
     public void onQuotaExceeded() {
         McTalking.LOGGER.warn("[MemoryCompaction] Quota exceeded during Live compaction");
+        QuotaTracker.reportQuotaExceeded(McTalkingConfig.CHEAP_LIVE_MODEL.getName());
         onError.run();
         close();
     }

--- a/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionWsClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/conversations/memory/MemoryCompactionWsClient.java
@@ -32,7 +32,7 @@ public class MemoryCompactionWsClient extends GeminiLiveClient {
 
     @Override
     public BidiGenerateContentSetup getSetup() {
-        var setup = new BidiGenerateContentSetup("models/" + McTalkingConfig.INSTANCE.instance().currentAiModel.getName());
+        var setup = new BidiGenerateContentSetup("models/" + McTalkingConfig.CHEAP_LIVE_MODEL);
 
         setup.generationConfig.responseModalities = ModalityModes.TEXT_AND_AUDIO.getModalities();
         setup.outputAudioTranscription = new JsonObject();

--- a/src/main/java/me/sshcrack/mc_talking/conversations/memory/data/CitizenMemories.java
+++ b/src/main/java/me/sshcrack/mc_talking/conversations/memory/data/CitizenMemories.java
@@ -18,6 +18,8 @@ import java.util.Set;
 import java.util.UUID;
 
 public class CitizenMemories {
+    public static final String SYSTEM_EVENT_PREFIX = "[SYSTEM]";
+
     private static final String TAG_FACTS_KEY = "facts";
     private static final String TAG_EVENTS_KEY = "events";
     private static final String TAG_RELATIONSHIPS_KEY = "relationships";

--- a/src/main/java/me/sshcrack/mc_talking/manager/CitizenWsClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/CitizenWsClient.java
@@ -200,6 +200,11 @@ public class CitizenWsClient extends GeminiWsClient {
     }
 
     @Override
+    protected String getModelName() {
+        return McTalkingConfig.INSTANCE.instance().currentAiModel.getName();
+    }
+
+    @Override
     protected void onQuotaExceededEvent(String message) {
         if (player != null) {
             Objects.requireNonNull(player.getServer()).execute(() -> {

--- a/src/main/java/me/sshcrack/mc_talking/manager/GeminiWsClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/GeminiWsClient.java
@@ -13,6 +13,7 @@ import me.sshcrack.gemini_live_lib.gson.RealtimeInput;
 import me.sshcrack.gemini_live_lib.websocket.handshake.ServerHandshake;
 import me.sshcrack.mc_talking.ConversationManager;
 import me.sshcrack.mc_talking.McTalking;
+import me.sshcrack.mc_talking.config.QuotaTracker;
 import me.sshcrack.mc_talking.config.ModalityModes;
 import me.sshcrack.mc_talking.duck.CitizenDataMemoryExtended;
 import me.sshcrack.mc_talking.manager.audio.AudioProvider;
@@ -63,9 +64,9 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
     }
 
     /**
-     * This variable is used to track if the quota has been exceeded
+     * Returns the model name string for quota tracking.
      */
-    private static boolean quotaExceeded;
+    protected abstract String getModelName();
 
     private boolean hasMadeInitialConnection = false;
     private long nextReconnectAllowedAt = 0;
@@ -179,7 +180,7 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
     }
 
     private boolean canAttemptRecovery() {
-        return !intentionalClose && !quotaExceeded
+        return !intentionalClose && !QuotaTracker.isQuotaExceeded(getModelName())
                 && wsSessionState != WsSessionState.TERMINAL_ERROR
                 && wsSessionState != WsSessionState.CLOSED
                 && wsSessionState != WsSessionState.QUOTA_EXCEEDED;
@@ -240,7 +241,7 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
 
     @Override
     public BidiGenerateContentSetup getSetup() {
-        var setup = new BidiGenerateContentSetup("models/" + McTalkingConfig.INSTANCE.instance().currentAiModel.getName());
+        var setup = new BidiGenerateContentSetup("models/" + getModelName());
 
         var modality = getEffectiveModality();
         setup.generationConfig.responseModalities = modality.getModalities();
@@ -605,7 +606,7 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
     @Override
     public void onQuotaExceeded() {
         McTalking.LOGGER.warn("Quota exceeded for Gemini API, please check your API key and usage limits.");
-        quotaExceeded = true;
+        QuotaTracker.reportQuotaExceeded(getModelName());
         setWsSessionState(WsSessionState.QUOTA_EXCEEDED, "quota exceeded");
         onQuotaExceededEvent("Quota exceeded for Gemini API, please check your API key and usage limits.");
     }
@@ -623,7 +624,7 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
             return;
         }
 
-        if (quotaExceeded) {
+        if (QuotaTracker.isQuotaExceeded(getModelName())) {
             return;
         }
 
@@ -672,7 +673,7 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
     @Override
     public void onError(Exception ex) {
         McTalking.LOGGER.error("Error in GeminiWsClient: ", ex);
-        if (intentionalClose || quotaExceeded) {
+        if (intentionalClose || QuotaTracker.isQuotaExceeded(getModelName())) {
             return;
         }
 
@@ -736,7 +737,7 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
 
     @Override
     public void reconnect() {
-        if (intentionalClose || quotaExceeded) {
+        if (intentionalClose || QuotaTracker.isQuotaExceeded(getModelName())) {
             return;
         }
         intentionalClose = false;

--- a/src/main/java/me/sshcrack/mc_talking/manager/GeminiWsClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/GeminiWsClient.java
@@ -85,6 +85,15 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
     protected boolean shouldEndConversation = false;
 
     /**
+     * The most recent text submitted via {@link #addPromptTextAfterTalkingComplete}.
+     * Saved so that after a session-token invalidation and reconnect the prompt can
+     * be re-queued, preventing system-controlled sessions (mumbling / urgent contact)
+     * from falling silent.
+     */
+    @Nullable
+    private String lastPromptText = null;
+
+    /**
      * Accumulates AI-generated text/transcription for the current turn to display in chat.
      */
     protected String currentTurnTranscript = "";
@@ -634,6 +643,18 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
             wsSessionState = WsSessionState.INVALID_SESSION_TOKEN;
             var mem = ((CitizenDataMemoryExtended) entity.getCitizenData()).mc_talking$getOrInitializeMemory();
             mem.setSessionToken("");
+
+            // If a system-controlled prompt (mumbling / urgent contact) was previously
+            // submitted, re-queue it so the AI is re-prompted after the new connection
+            // establishes, rather than sitting in LISTENING state silently.
+            if (lastPromptText != null) {
+                synchronized (pendingSystemText) {
+                    if (!pendingSystemText.contains(lastPromptText)) {
+                        pendingSystemText.add(lastPromptText);
+                    }
+                }
+            }
+
             ensureConnectionForQueuedInput("session token invalidated");
             return;
         }
@@ -711,7 +732,20 @@ public abstract class GeminiWsClient extends GeminiLiveClient {
         send(ClientMessages.input(input));
     }
 
+    /**
+     * Queues {@code text} to be sent to the API after the current AI turn finishes.
+     * If the session is not yet ready the text is buffered in {@link #pendingSystemText}
+     * and sent once setup completes.
+     *
+     * <p>The text is also saved to {@link #lastPromptText} so that if the session
+     * token is later invalidated the prompt can be replayed on the new connection,
+     * preventing system-controlled conversations from going silent.</p>
+     *
+     * @param text the text prompt to send after the current AI turn completes
+     */
     public void addPromptTextAfterTalkingComplete(String text) {
+        this.lastPromptText = text;
+
         if (sentGeneratingStatus)
             onGenerationPaused();
 

--- a/src/main/java/me/sshcrack/mc_talking/mixin/AbstractRequestMixin.java
+++ b/src/main/java/me/sshcrack/mc_talking/mixin/AbstractRequestMixin.java
@@ -6,7 +6,7 @@ import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.request.RequestState;
 import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Delivery;
 import com.minecolonies.core.colony.requestsystem.requests.AbstractRequest;
-import me.sshcrack.mc_talking.mixin.support.PlayerFulfillmentHandler;
+import me.sshcrack.mc_talking.support.PlayerFulfillmentHandler;
 import me.sshcrack.mc_talking.pregen.DeliveryInteractionManager;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;

--- a/src/main/java/me/sshcrack/mc_talking/mixin/UpdateRequestStateMixin.java
+++ b/src/main/java/me/sshcrack/mc_talking/mixin/UpdateRequestStateMixin.java
@@ -3,7 +3,7 @@ package me.sshcrack.mc_talking.mixin;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.requestsystem.request.RequestState;
 import com.minecolonies.core.network.messages.server.colony.UpdateRequestStateMessage;
-import me.sshcrack.mc_talking.mixin.support.PlayerFulfillmentHandler;
+import me.sshcrack.mc_talking.support.PlayerFulfillmentHandler;
 import net.minecraft.server.level.ServerPlayer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;

--- a/src/main/java/me/sshcrack/mc_talking/pregen/DeliveryInteractionManager.java
+++ b/src/main/java/me/sshcrack/mc_talking/pregen/DeliveryInteractionManager.java
@@ -13,6 +13,7 @@ import me.sshcrack.gemini_live_lib.misc.GeminiTTS.AudioChunk;
 import me.sshcrack.mc_talking.ConversationManager;
 import me.sshcrack.mc_talking.McTalking;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
+import me.sshcrack.mc_talking.config.QuotaTracker;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
@@ -362,21 +363,24 @@ public class DeliveryInteractionManager {
     }
 
     private static void startPregeneration(AbstractEntityCitizen citizen, String prompt, java.util.function.Consumer<AudioChunk> onComplete) {
-        if (!ConversationManager.hasFreeCapacity(1)) return;
-        if (!ConversationManager.claimSlot(citizen, false)) return;
+        if (QuotaTracker.isQuotaExceeded(McTalkingConfig.CHEAP_LIVE_MODEL.getName())) return;
+        if (!ConversationManager.claimBackgroundSlot(citizen, "pregen")) return;
 
-        PregenerationGeminiClient client = new PregenerationGeminiClient(citizen, prompt, audio -> {
-            ConversationManager.releaseSlot(citizen);
-            onComplete.accept(audio);
-        }, () -> {
-            ConversationManager.releaseSlot(citizen);
-        });
+        PregenerationGeminiClient client = new PregenerationGeminiClient(citizen, prompt, McTalkingConfig.CHEAP_LIVE_MODEL,
+                audio -> {
+                    ConversationManager.releaseBackgroundSlot(citizen.getUUID());
+                    onComplete.accept(audio);
+                },
+                () -> {
+                    ConversationManager.releaseBackgroundSlot(citizen.getUUID());
+                });
 
         try {
             client.connect();
+            ConversationManager.registerBackgroundClient(citizen.getUUID(), client);
         } catch (Exception e) {
             McTalking.LOGGER.error("[DeliveryInteraction] Failed to connect for citizen {}", citizen.getUUID(), e);
-            ConversationManager.releaseSlot(citizen);
+            ConversationManager.releaseBackgroundSlot(citizen.getUUID());
         }
     }
 }

--- a/src/main/java/me/sshcrack/mc_talking/pregen/DeliveryInteractionManager.java
+++ b/src/main/java/me/sshcrack/mc_talking/pregen/DeliveryInteractionManager.java
@@ -14,6 +14,7 @@ import me.sshcrack.mc_talking.ConversationManager;
 import me.sshcrack.mc_talking.McTalking;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
 import me.sshcrack.mc_talking.config.QuotaTracker;
+import me.sshcrack.mc_talking.util.BackgroundSlotType;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
@@ -364,7 +365,7 @@ public class DeliveryInteractionManager {
 
     private static void startPregeneration(AbstractEntityCitizen citizen, String prompt, java.util.function.Consumer<AudioChunk> onComplete) {
         if (QuotaTracker.isQuotaExceeded(McTalkingConfig.CHEAP_LIVE_MODEL.getName())) return;
-        if (!ConversationManager.claimBackgroundSlot(citizen, "pregen")) return;
+        if (!ConversationManager.claimBackgroundSlot(citizen, BackgroundSlotType.PREGEN)) return;
 
         PregenerationGeminiClient client = new PregenerationGeminiClient(citizen, prompt, McTalkingConfig.CHEAP_LIVE_MODEL,
                 audio -> {

--- a/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationGeminiClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationGeminiClient.java
@@ -39,7 +39,7 @@ public class PregenerationGeminiClient extends GeminiLiveClient {
 
     @Override
     public BidiGenerateContentSetup getSetup() {
-        var setup = new BidiGenerateContentSetup("models/" + McTalkingConfig.INSTANCE.instance().currentAiModel.getName());
+        var setup = new BidiGenerateContentSetup("models/" + McTalkingConfig.CHEAP_LIVE_MODEL);
         setup.generationConfig.responseModalities = ModalityModes.AUDIO.getModalities();
         setup.generationConfig.speechConfig = new BidiGenerateContentSetup.GenerationConfig.SpeechConfig();
         setup.generationConfig.speechConfig.language_code = McTalkingConfig.INSTANCE.instance().language;

--- a/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationGeminiClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationGeminiClient.java
@@ -8,8 +8,10 @@ import me.sshcrack.gemini_live_lib.gson.ClientMessages;
 import me.sshcrack.gemini_live_lib.gson.RealtimeInput;
 import me.sshcrack.gemini_live_lib.websocket.handshake.ServerHandshake;
 import me.sshcrack.mc_talking.McTalking;
+import me.sshcrack.mc_talking.config.AvailableAI;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
 import me.sshcrack.mc_talking.config.ModalityModes;
+import me.sshcrack.mc_talking.config.QuotaTracker;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -24,22 +26,26 @@ import static me.sshcrack.mc_talking.McTalkingVoicechatPlugin.vcApi;
 public class PregenerationGeminiClient extends GeminiLiveClient {
     private final AbstractEntityCitizen entity;
     private final String promptText;
+    private final String modelName;
+    private final AvailableAI modelAi;
     private final Consumer<AudioChunk> onComplete;
     private final Runnable onError;
     private final ByteArrayOutputStream audioBuffer = new ByteArrayOutputStream();
     private static final int MAX_BUFFER_SIZE = 50 * 1024 * 1024; // 50 MB max
 
-    public PregenerationGeminiClient(AbstractEntityCitizen entity, String promptText, Consumer<AudioChunk> onComplete, Runnable onError) {
+    public PregenerationGeminiClient(AbstractEntityCitizen entity, String promptText, AvailableAI model, Consumer<AudioChunk> onComplete, Runnable onError) {
         super(McTalkingConfig.INSTANCE.instance().geminiApiKey);
         this.entity = entity;
         this.promptText = promptText;
+        this.modelAi = model;
+        this.modelName = model.getName();
         this.onComplete = onComplete;
         this.onError = onError;
     }
 
     @Override
     public BidiGenerateContentSetup getSetup() {
-        var setup = new BidiGenerateContentSetup("models/" + McTalkingConfig.CHEAP_LIVE_MODEL);
+        var setup = new BidiGenerateContentSetup("models/" + modelName);
         setup.generationConfig.responseModalities = ModalityModes.AUDIO.getModalities();
         setup.generationConfig.speechConfig = new BidiGenerateContentSetup.GenerationConfig.SpeechConfig();
         setup.generationConfig.speechConfig.language_code = McTalkingConfig.INSTANCE.instance().language;
@@ -48,7 +54,7 @@ public class PregenerationGeminiClient extends GeminiLiveClient {
         var uuid = entity.getUUID();
         setup.generationConfig.speechConfig.voice_config = new BidiGenerateContentSetup.GenerationConfig.SpeechConfig.VoiceConfig();
         setup.generationConfig.speechConfig.voice_config.prebuiltVoiceConfig = new BidiGenerateContentSetup.GenerationConfig.SpeechConfig.PrebuiltVoiceConfig();
-        setup.generationConfig.speechConfig.voice_config.prebuiltVoiceConfig.voice_name = McTalkingConfig.INSTANCE.instance().currentAiModel.getRandomVoice(uuid, female);
+        setup.generationConfig.speechConfig.voice_config.prebuiltVoiceConfig.voice_name = modelAi.getRandomVoice(uuid, female);
 
         var sys = new BidiGenerateContentSetup.SystemInstruction();
         var p = new BidiGenerateContentSetup.SystemInstruction.Part(
@@ -127,6 +133,7 @@ public class PregenerationGeminiClient extends GeminiLiveClient {
     @Override
     public void onQuotaExceeded() {
         McTalking.LOGGER.warn("Quota exceeded during audio pregeneration");
+        QuotaTracker.reportQuotaExceeded(modelName);
         if (onError != null) onError.run();
         close();
     }

--- a/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationGeminiClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationGeminiClient.java
@@ -15,9 +15,12 @@ import me.sshcrack.mc_talking.config.QuotaTracker;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.function.Consumer;
 
 import me.sshcrack.gemini_live_lib.misc.GeminiTTS.AudioChunk;
+import me.sshcrack.mc_talking.api.prompt.CitizenPromptService;
+import me.sshcrack.mc_talking.manager.CitizenPromptViewFactory;
 import me.sshcrack.mc_talking.util.AudioHelper;
 
 import static me.sshcrack.mc_talking.McTalkingVoicechatPlugin.TARGET_SAMPLE_RATE;
@@ -29,9 +32,17 @@ public class PregenerationGeminiClient extends GeminiLiveClient {
     private final String modelName;
     private final AvailableAI modelAi;
     private final Consumer<AudioChunk> onComplete;
-    private final Runnable onError;
+    private Runnable onError;
     private final ByteArrayOutputStream audioBuffer = new ByteArrayOutputStream();
     private static final int MAX_BUFFER_SIZE = 50 * 1024 * 1024; // 50 MB max
+
+    /**
+     * Set to {@code true} once {@link #onTurnComplete} fires (successfully or not).
+     * Used by {@link #onClose} to decide whether the session ended normally — if
+     * {@code false}, the close is treated as an error and the cleanup callback is
+     * invoked to release the slot and decrement counters.
+     */
+    private boolean completed = false;
 
     public PregenerationGeminiClient(AbstractEntityCitizen entity, String promptText, AvailableAI model, Consumer<AudioChunk> onComplete, Runnable onError) {
         super(McTalkingConfig.INSTANCE.instance().geminiApiKey);
@@ -57,9 +68,9 @@ public class PregenerationGeminiClient extends GeminiLiveClient {
         setup.generationConfig.speechConfig.voice_config.prebuiltVoiceConfig.voice_name = modelAi.getRandomVoice(uuid, female);
 
         var sys = new BidiGenerateContentSetup.SystemInstruction();
-        var p = new BidiGenerateContentSetup.SystemInstruction.Part(
-                "You are " + entity.getCitizenData().getName() + ", a citizen in a Minecraft colony."
-        );
+        var view = CitizenPromptViewFactory.create(entity.getCitizenData(), new HashMap<>(), null);
+        var prompt = CitizenPromptService.generateSystemControlledRoleplayPrompt(view);
+        var p = new BidiGenerateContentSetup.SystemInstruction.Part(prompt);
         sys.parts.add(p);
         setup.systemInstruction = sys;
 
@@ -93,7 +104,10 @@ public class PregenerationGeminiClient extends GeminiLiveClient {
         try {
             if (audioBuffer.size() + processed.length > MAX_BUFFER_SIZE) {
                 McTalking.LOGGER.error("Pregenerated audio buffer exceeded maximum size, aborting");
-                if (onError != null) onError.run();
+                if (onError != null) {
+                    onError.run();
+                    onError = null;
+                }
                 close();
                 return;
             }
@@ -105,12 +119,16 @@ public class PregenerationGeminiClient extends GeminiLiveClient {
 
     @Override
     public void onTurnComplete() {
+        completed = true;
         byte[] audioData = audioBuffer.toByteArray();
         if (audioData.length > 0) {
             onComplete.accept(new AudioChunk(audioData, TARGET_SAMPLE_RATE));
         } else {
             McTalking.LOGGER.warn("Pregeneration completed without producing audio");
-            if (onError != null) onError.run();
+            if (onError != null) {
+                onError.run();
+                onError = null;
+            }
         }
         close();
     }
@@ -134,15 +152,39 @@ public class PregenerationGeminiClient extends GeminiLiveClient {
     public void onQuotaExceeded() {
         McTalking.LOGGER.warn("Quota exceeded during audio pregeneration");
         QuotaTracker.reportQuotaExceeded(modelName);
-        if (onError != null) onError.run();
+        if (onError != null) {
+            onError.run();
+            onError = null;
+        }
         close();
     }
 
     @Override
     public void onError(Exception ex) {
         McTalking.LOGGER.error("Error during pregeneration", ex);
-        if (onError != null) onError.run();
+        if (onError != null) {
+            onError.run();
+            onError = null;
+        }
         close();
+    }
+
+    @Override
+    public void onClose(int code, String reason, boolean remote) {
+        try {
+            super.onClose(code, reason, remote);
+        } catch (Exception e) {
+            McTalking.LOGGER.error("Error in PregenerationGeminiClient.onClose", e);
+        }
+
+        // If the session closed before onTurnComplete fired (e.g. auth failure,
+        // server-side error during setup, or an abnormal WebSocket close), clean
+        // up the slot and counters so no stale entries are left behind.
+        if (!completed && onError != null) {
+            McTalking.LOGGER.warn("Pregeneration session closed before completion (code={}, reason={})", code, reason);
+            onError.run();
+            onError = null;
+        }
     }
 
     @Override

--- a/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationTaskService.java
+++ b/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationTaskService.java
@@ -3,7 +3,9 @@ package me.sshcrack.mc_talking.pregen;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import me.sshcrack.mc_talking.ConversationManager;
 import me.sshcrack.mc_talking.McTalking;
+import me.sshcrack.mc_talking.config.AvailableAI;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
+import me.sshcrack.mc_talking.config.QuotaTracker;
 import me.sshcrack.mc_talking.util.CitizenHelper;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -22,8 +24,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class PregenerationTaskService {
-    private static final int MAX_CONCURRENT_PREGENS = 2;
     private static final AtomicInteger generatingCount = new AtomicInteger(0);
+    private static final AtomicInteger playerGreetingActiveCount = new AtomicInteger(0);
     private static int tickCounter = 0;
     private static int decayTickCounter = 0;
     private static final Map<UUID, Long> lastThreatPlayTime = new ConcurrentHashMap<>();
@@ -53,61 +55,61 @@ public class PregenerationTaskService {
 
     public static void tick(MinecraftServer server) {
         tickCounter++;
-        if (tickCounter % 200 != 0) return; // Check every 10 seconds
+        if (tickCounter % 200 != 0) return;
 
         decayTickCounter++;
         if (decayTickCounter % 600 == 0) {
             HeatmapTracker.decayScores();
         }
 
-        if (generatingCount.get() >= MAX_CONCURRENT_PREGENS) return;
+        if (!McTalkingConfig.hasGeminiApiKey()) return;
 
-        List<HeatmapTracker.UUIDPair> topPairs = HeatmapTracker.getTopPairs(5);
-        for (HeatmapTracker.UUIDPair pair : topPairs) {
-            AbstractEntityCitizen c1 = findCitizen(server, pair.id1());
-            AbstractEntityCitizen c2 = findCitizen(server, pair.id2());
-
-            if (c1 != null && c2 != null) {
-                if (ConversationManager.isCitizenBusy(c1) || ConversationManager.isCitizenBusy(c2)) {
-                    continue;
-                }
-
-                // Check if we need greeting for c1 -> c2
-                if (!hasGreeting(c1.getUUID(), c2.getUUID())) {
-                    startPregenerationIfPossible(c1, "Generate a brief 1-sentence passing greeting for your friend " + c2.getCitizenData().getName() + ".", (audio) -> {
-                        putGreeting(c1.getUUID(), c2.getUUID(), audio);
-                    });
-                    return;
-                }
-
-                // Check if we need greeting for c2 -> c1
-                if (!hasGreeting(c2.getUUID(), c1.getUUID())) {
-                    startPregenerationIfPossible(c2, "Generate a brief 1-sentence passing greeting for your friend " + c1.getCitizenData().getName() + ".", (audio) -> {
-                        putGreeting(c2.getUUID(), c1.getUUID(), audio);
-                    });
-                    return;
-                }
-            }
-        }
-
-        // Player greeting pregen: pregenerate greetings for frequent citizen-player pairs
-        if (McTalkingConfig.INSTANCE.instance().enablePlayerGreetingPregen) {
+        // Priority 1: Player greeting pregen — ensure at least 1 is running if possible
+        if (McTalkingConfig.INSTANCE.instance().enablePlayerGreetingPregen && playerGreetingActiveCount.get() < 2) {
             List<PlayerHeatmapTracker.CitizenPlayerPair> topPlayerPairs = PlayerHeatmapTracker.getTopPairs(5);
             for (PlayerHeatmapTracker.CitizenPlayerPair pair : topPlayerPairs) {
                 AbstractEntityCitizen citizen = findCitizen(server, pair.citizenId());
                 ServerPlayer player = findPlayer(server, pair.playerId());
 
                 if (citizen != null && player != null) {
-                    if (ConversationManager.isCitizenBusy(citizen)) {
-                        continue;
-                    }
+                    if (ConversationManager.isCitizenBusy(citizen)) continue;
 
                     String cacheKey = pair.citizenId() + ":" + pair.playerId();
                     if (!playerGreetingCache.containsKey(cacheKey)) {
                         String playerName = player.getName().getString();
                         startPregenerationIfPossible(citizen,
                                 "Generate a brief 1-sentence greeting for " + playerName + " who is approaching you. Greet them by name and say hello, you're happy to see them.",
-                                (audio) -> putPlayerGreeting(pair.citizenId(), pair.playerId(), audio));
+                                (audio) -> putPlayerGreeting(pair.citizenId(), pair.playerId(), audio),
+                                false, true);
+                        return;
+                    }
+                }
+            }
+        }
+
+        // Priority 2: Citizen↔citizen greeting pregen — if background pool has capacity
+        if (ConversationManager.hasFreeBackgroundCapacity(1)) {
+            List<HeatmapTracker.UUIDPair> topPairs = HeatmapTracker.getTopPairs(5);
+            for (HeatmapTracker.UUIDPair pair : topPairs) {
+                AbstractEntityCitizen c1 = findCitizen(server, pair.id1());
+                AbstractEntityCitizen c2 = findCitizen(server, pair.id2());
+
+                if (c1 != null && c2 != null) {
+                    if (ConversationManager.isCitizenBusy(c1) || ConversationManager.isCitizenBusy(c2)) continue;
+
+                    if (!hasGreeting(c1.getUUID(), c2.getUUID())) {
+                        startPregenerationIfPossible(c1,
+                                "Generate a brief 1-sentence passing greeting for your friend " + c2.getCitizenData().getName() + ".",
+                                (audio) -> putGreeting(c1.getUUID(), c2.getUUID(), audio),
+                                false, false);
+                        return;
+                    }
+
+                    if (!hasGreeting(c2.getUUID(), c1.getUUID())) {
+                        startPregenerationIfPossible(c2,
+                                "Generate a brief 1-sentence passing greeting for your friend " + c1.getCitizenData().getName() + ".",
+                                (audio) -> putGreeting(c2.getUUID(), c1.getUUID(), audio),
+                                false, false);
                         return;
                     }
                 }
@@ -115,39 +117,53 @@ public class PregenerationTaskService {
         }
     }
 
-    private static void startPregenerationIfPossible(AbstractEntityCitizen citizen, String prompt, java.util.function.Consumer<AudioChunk> onComplete) {
-        if (!McTalkingConfig.hasGeminiApiKey()) {
-            return;
-        }
+    private static void startPregenerationIfPossible(AbstractEntityCitizen citizen, String prompt,
+                                                      java.util.function.Consumer<AudioChunk> onComplete,
+                                                      boolean isThreat, boolean isPlayerGreeting) {
+        if (!McTalkingConfig.hasGeminiApiKey()) return;
 
-        if (generatingCount.get() >= MAX_CONCURRENT_PREGENS)
-            return;
-
-        if (!ConversationManager.hasFreeCapacity(1))
-            return;
-
-        if (!ConversationManager.claimSlot(citizen, false)) {
-            return;
+        AvailableAI model;
+        if (isThreat) {
+            model = McTalkingConfig.INSTANCE.instance().currentAiModel;
+            if (!ConversationManager.claimSlot(citizen, false)) return;
+        } else {
+            model = McTalkingConfig.CHEAP_LIVE_MODEL;
+            if (QuotaTracker.isQuotaExceeded(model.getName())) return;
+            if (!ConversationManager.claimBackgroundSlot(citizen, "pregen")) return;
         }
 
         generatingCount.incrementAndGet();
-        McTalking.LOGGER.info("[Pregeneration] Starting audio pregeneration for citizen {}", citizen.getUUID());
+        if (isPlayerGreeting) playerGreetingActiveCount.incrementAndGet();
 
-        PregenerationGeminiClient client = new PregenerationGeminiClient(citizen, prompt, audio -> {
-            ConversationManager.releaseSlot(citizen);
-            generatingCount.decrementAndGet();
-            onComplete.accept(audio);
-        }, () -> {
-            generatingCount.decrementAndGet();
-            ConversationManager.releaseSlot(citizen);
-        });
+        McTalking.LOGGER.info("[Pregeneration] Starting {} for citizen {} (threat={}, model={})",
+                isThreat ? "threat" : "pregen", citizen.getUUID(), isThreat, model.getName());
+
+        PregenerationGeminiClient client = new PregenerationGeminiClient(citizen, prompt, model,
+                audio -> {
+                    if (isThreat) ConversationManager.releaseSlot(citizen);
+                    else ConversationManager.releaseBackgroundSlot(citizen.getUUID());
+                    generatingCount.decrementAndGet();
+                    if (isPlayerGreeting) playerGreetingActiveCount.decrementAndGet();
+                    onComplete.accept(audio);
+                },
+                () -> {
+                    if (isThreat) ConversationManager.releaseSlot(citizen);
+                    else ConversationManager.releaseBackgroundSlot(citizen.getUUID());
+                    generatingCount.decrementAndGet();
+                    if (isPlayerGreeting) playerGreetingActiveCount.decrementAndGet();
+                });
 
         try {
             client.connect();
+            if (!isThreat) {
+                ConversationManager.registerBackgroundClient(citizen.getUUID(), client);
+            }
         } catch (Exception e) {
             McTalking.LOGGER.error("[Pregeneration] Failed to connect for citizen {}", citizen.getUUID(), e);
+            if (isThreat) ConversationManager.releaseSlot(citizen);
+            else ConversationManager.releaseBackgroundSlot(citizen.getUUID());
             generatingCount.decrementAndGet();
-            ConversationManager.releaseSlot(citizen);
+            if (isPlayerGreeting) playerGreetingActiveCount.decrementAndGet();
         }
     }
 
@@ -189,17 +205,15 @@ public class PregenerationTaskService {
             }
         }
 
-        // Generate on-demand (no caching). On completion, attempt immediate playback and update cooldown.
         startPregenerationIfPossible(citizen, prompt, audio -> {
             long playedAt = System.currentTimeMillis();
-            // Attempt playback
             boolean played = PregenerationPlayback.playAudioIfPossible(citizen, audio);
             if (played) {
                 lastThreatPlayTime.put(citizen.getUUID(), playedAt);
             } else {
                 lastThreatPlayTime.remove(citizen.getUUID());
             }
-        });
+        }, true, false);
     }
 
     // Cache management methods
@@ -280,7 +294,7 @@ public class PregenerationTaskService {
 
     public static void generatePlayerGreetingNow(AbstractEntityCitizen citizen, String playerName, java.util.function.Consumer<AudioChunk> onComplete) {
         String prompt = "Generate a brief 1-sentence greeting for " + playerName + " who is approaching you. Greet them by name and say hello, you're happy to see them.";
-        startPregenerationIfPossible(citizen, prompt, onComplete);
+        startPregenerationIfPossible(citizen, prompt, onComplete, false, true);
     }
 
     public static boolean isPregenerating() {
@@ -290,6 +304,7 @@ public class PregenerationTaskService {
     public static void cleanup() {
         lastThreatPlayTime.clear();
         generatingCount.set(0);
+        playerGreetingActiveCount.set(0);
         tickCounter = 0;
         decayTickCounter = 0;
         lastGreetingPlayTime.clear();

--- a/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationTaskService.java
+++ b/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationTaskService.java
@@ -86,6 +86,27 @@ public class PregenerationTaskService {
                     }
                 }
             }
+
+            // Fallback: no heatmap data yet or all pairs were busy/cached — pick any
+            // online player and any non-busy citizen to seed the greeting cache.
+            for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+                for (ServerLevel level : server.getAllLevels()) {
+                    for (Entity entity : level.getEntities().getAll()) {
+                        if (!(entity instanceof AbstractEntityCitizen citizen)) continue;
+                        if (ConversationManager.isCitizenBusy(citizen)) continue;
+
+                        String cacheKey = citizen.getUUID() + ":" + player.getUUID();
+                        if (!playerGreetingCache.containsKey(cacheKey)) {
+                            String playerName = player.getName().getString();
+                            startPregenerationIfPossible(citizen,
+                                    "Generate a brief 1-sentence greeting for " + playerName + " who is approaching you. Greet them by name and say hello, you're happy to see them.",
+                                    (audio) -> putPlayerGreeting(citizen.getUUID(), player.getUUID(), audio),
+                                    false, true);
+                            return;
+                        }
+                    }
+                }
+            }
         }
 
         // Priority 2: Citizen↔citizen greeting pregen — if background pool has capacity

--- a/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationTaskService.java
+++ b/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationTaskService.java
@@ -6,6 +6,7 @@ import me.sshcrack.mc_talking.McTalking;
 import me.sshcrack.mc_talking.config.AvailableAI;
 import me.sshcrack.mc_talking.config.McTalkingConfig;
 import me.sshcrack.mc_talking.config.QuotaTracker;
+import me.sshcrack.mc_talking.util.BackgroundSlotType;
 import me.sshcrack.mc_talking.util.CitizenHelper;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -129,7 +130,7 @@ public class PregenerationTaskService {
         } else {
             model = McTalkingConfig.CHEAP_LIVE_MODEL;
             if (QuotaTracker.isQuotaExceeded(model.getName())) return;
-            if (!ConversationManager.claimBackgroundSlot(citizen, "pregen")) return;
+            if (!ConversationManager.claimBackgroundSlot(citizen, BackgroundSlotType.PREGEN)) return;
         }
 
         generatingCount.incrementAndGet();
@@ -299,6 +300,17 @@ public class PregenerationTaskService {
 
     public static boolean isPregenerating() {
         return generatingCount.get() > 0;
+    }
+
+    public static int getGreetingCount(UUID citizenId) {
+        Map<UUID, AudioChunk> friends = greetingCache.get(citizenId);
+        return friends != null ? friends.size() : 0;
+    }
+
+    public static int getPlayerGreetingCount(UUID citizenId) {
+        return (int) playerGreetingCache.keySet().stream()
+                .filter(k -> k.startsWith(citizenId + ":"))
+                .count();
     }
 
     public static void cleanup() {

--- a/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationTaskService.java
+++ b/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationTaskService.java
@@ -315,7 +315,10 @@ public class PregenerationTaskService {
     }
 
     public static void generatePlayerGreetingNow(AbstractEntityCitizen citizen, String playerName, java.util.function.Consumer<AudioChunk> onComplete) {
-        String prompt = "Generate a brief 1-sentence greeting for " + playerName + " who is approaching you. Greet them by name and say hello, you're happy to see them.";
+        String prompt = "You are greeting " + playerName + " who has just approached you. " +
+                "Generate a single brief greeting sentence that authentically reflects your current mood, " +
+                "health, concerns, and relationship with this person. " +
+                "Do not use markdown. Stay in character.";
         startPregenerationIfPossible(citizen, prompt, onComplete, false, true);
     }
 

--- a/src/main/java/me/sshcrack/mc_talking/rumor/RumorMillService.java
+++ b/src/main/java/me/sshcrack/mc_talking/rumor/RumorMillService.java
@@ -19,7 +19,8 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class RumorMillService {
-    private RumorMillService() {}
+    private RumorMillService() {
+    }
 
     public static void tick(MinecraftServer server) {
         var cfg = McTalkingConfig.INSTANCE.instance();
@@ -89,7 +90,7 @@ public class RumorMillService {
         var sourceMem = sourceData.mc_talking$getMemory();
         if (sourceMem == null) return false;
 
-        String content = null;
+        String content;
 
         if (sourceMem.hasPendingRumor()) {
             content = sourceMem.drainPendingRumor();
@@ -99,7 +100,7 @@ public class RumorMillService {
 
             List<String> firstHand = new ArrayList<>();
             for (String e : events) {
-                if (!e.startsWith("Rumor:")) {
+                if (!e.startsWith("Rumor:") && !e.startsWith(CitizenMemories.SYSTEM_EVENT_PREFIX)) {
                     firstHand.add(e);
                 }
             }

--- a/src/main/java/me/sshcrack/mc_talking/support/PlayerFulfillmentHandler.java
+++ b/src/main/java/me/sshcrack/mc_talking/support/PlayerFulfillmentHandler.java
@@ -7,13 +7,15 @@ import com.minecolonies.api.colony.requestsystem.manager.IRequestManager;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
 import me.sshcrack.mc_talking.McTalking;
+import me.sshcrack.mc_talking.conversations.memory.data.CitizenMemories;
 import me.sshcrack.mc_talking.duck.CitizenDataMemoryExtended;
 import net.minecraft.server.level.ServerPlayer;
 
 public class PlayerFulfillmentHandler {
     private static final ThreadLocal<ServerPlayer> CURRENT_FULFILLER = new ThreadLocal<>();
 
-    private PlayerFulfillmentHandler() {}
+    private PlayerFulfillmentHandler() {
+    }
 
     public static void setPendingFulfiller(ServerPlayer player) {
         CURRENT_FULFILLER.set(player);
@@ -36,14 +38,7 @@ public class PlayerFulfillmentHandler {
         ServerPlayer player = consumePendingFulfiller();
         if (player == null) return;
 
-        String itemName = "something";
-        if (request.getRequest() instanceof IDeliverable deliverable) {
-            var result = deliverable.getResult();
-            if (result != null && !result.isEmpty()) {
-                itemName = result.getHoverName().getString();
-            }
-        }
-
+        String itemName = request.getShortDisplayString().getString();
         String playerName = player.getName().getString();
         ICitizenData foundCitizen = null;
 
@@ -65,10 +60,10 @@ public class PlayerFulfillmentHandler {
 
         var mem = ((CitizenDataMemoryExtended) foundCitizen).mc_talking$getOrInitializeMemory();
         mem.addEvent(String.format(
-            "The player %s brought me the %s I needed. I'm grateful.",
-            playerName, itemName));
+                CitizenMemories.SYSTEM_EVENT_PREFIX + " The player %s brought me the %s I needed. I'm grateful.",
+                playerName, itemName));
 
         McTalking.LOGGER.info("[Fulfillment] Citizen {} remembers fulfillment by {} of {}",
-            foundCitizen.getName(), playerName, itemName);
+                foundCitizen.getName(), playerName, itemName);
     }
 }

--- a/src/main/java/me/sshcrack/mc_talking/support/PlayerFulfillmentHandler.java
+++ b/src/main/java/me/sshcrack/mc_talking/support/PlayerFulfillmentHandler.java
@@ -1,4 +1,4 @@
-package me.sshcrack.mc_talking.mixin.support;
+package me.sshcrack.mc_talking.support;
 
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;

--- a/src/main/java/me/sshcrack/mc_talking/util/BackgroundSlotType.java
+++ b/src/main/java/me/sshcrack/mc_talking/util/BackgroundSlotType.java
@@ -1,0 +1,6 @@
+package me.sshcrack.mc_talking.util;
+
+public enum BackgroundSlotType {
+    PREGEN,
+    COMPACTION
+}

--- a/src/main/resources/assets/mc_talking/lang/en_us.json
+++ b/src/main/resources/assets/mc_talking/lang/en_us.json
@@ -80,6 +80,10 @@
   "mc_talking.debug.status_pregeneration": "Pregeneration: %s (%s)",
   "mc_talking.debug.status_compaction": "MemCompaction: %s [%s] (%d active)",
 
+  "mc_talking.debug.status_quota": "Live Model Quota: %s",
+
+  "mc_talking.debug.status_bg_slots": "Background Slots: %d/%d",
+
   "mc_talking.debug.connections_header": "--- Active Connections (%d) ---",
 
   "mc_talking.debug.citizen_header": "--- Citizen Info: %s ---",

--- a/src/main/resources/assets/mc_talking/lang/en_us.json
+++ b/src/main/resources/assets/mc_talking/lang/en_us.json
@@ -125,6 +125,8 @@
   "yacl3.config.mc_talking:config.sendMumblingAndConversationsToChat.desc": "If enabled, text messages from mumbling and citizen-to-citizen conversations will also be sent to nearby players in chat.",
   "yacl3.config.mc_talking:config.maxConcurrentAgents": "Max Concurrent Agents",
   "yacl3.config.mc_talking:config.maxConcurrentAgents.desc": "Maximum number of simultaneous citizen AI sessions. Player conversations have priority and can evict non-player sessions when full.",
+  "yacl3.config.mc_talking:config.maxConcurrentBackground": "Max Concurrent Background",
+  "yacl3.config.mc_talking:config.maxConcurrentBackground.desc": "Maximum concurrent background connections for the flash2.5 live model used by memory compaction and greeting pregeneration.",
   "yacl3.config.mc_talking:config.maxConversationDistance": "Max Conversation Distance",
   "yacl3.config.mc_talking:config.maxConversationDistance.desc": "If you move farther than this many blocks from your active citizen, the player conversation ends automatically.",
   "yacl3.config.mc_talking:config.modality": "Modality",


### PR DESCRIPTION
## Summary

Redirects memory compaction (LIVE mode) and pregeneration (greetings, threats) from `gemini-3.1-flash-live-preview` to the cheaper `gemini-live-2.5-flash-native-audio` model to avoid exhausting the 3.1 Flash Live TPM quota.

## Problem

The TPM quota for `gemini-3.1-flash-live-preview` was being consumed by background tasks that don't need full conversational quality. Every Live WebSocket session counts toward this model's TPM, and compaction + pregeneration sessions were burning through quota unnecessarily.

## Solution

Added a `CHEAP_LIVE_MODEL` constant and used it in both `MemoryCompactionWsClient` and `PregenerationGeminiClient` instead of the user-configurable `currentAiModel`. The cheap model has its own TPM pool.

## Changes

| File | Change |
|------|--------|
| `McTalkingConfig.java` | Added `CHEAP_LIVE_MODEL = "gemini-live-2.5-flash-native-audio"` |
| `MemoryCompactionWsClient.java` | Model path → `CHEAP_LIVE_MODEL` |
| `PregenerationGeminiClient.java` | Model path → `CHEAP_LIVE_MODEL` |

Voice selection remains from `currentAiModel.getRandomVoice()` since voices are shared across Live models. Flash REST and TTS calls are unaffected.

Closes #80