### PR TITLE
fix: prevent duplicate audio when pregenerated greeting plays (#90)

### DIFF
--- a/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationPlayback.java
+++ b/src/main/java/me/sshcrack/mc_talking/pregen/PregenerationPlayback.java
@@ -32,6 +32,7 @@ public class PregenerationPlayback {
         if (ACTIVE_PREGENERATED_PLAYBACK.putIfAbsent(citizenId, Boolean.TRUE) != null) {
             return false;
         }
+        ConversationManager.markBusy(citizen);
 
         try {
             McTalking.LOGGER.info("Playing back pregenerated audio for {}", citizen.getCitizenData().getName());
@@ -39,11 +40,13 @@ public class PregenerationPlayback {
             AudioChannel channel = audioProvider.createChannel();
             if (channel == null) {
                 releasePlaybackSlot(citizenId);
+                ConversationManager.markNotBusy(citizen);
                 return false;
             }
 
             if (audioData == null || audioData.audioBytes().length == 0) {
                 releasePlaybackSlot(citizenId);
+                ConversationManager.markNotBusy(citizen);
                 return false;
             }
 
@@ -60,6 +63,7 @@ public class PregenerationPlayback {
                     stream.close();
                 } finally {
                     releasePlaybackSlot(citizenId);
+                    ConversationManager.markNotBusy(citizen);
                 }
             });
 
@@ -68,6 +72,7 @@ public class PregenerationPlayback {
             return true;
         } catch (RuntimeException e) {
             releasePlaybackSlot(citizenId);
+            ConversationManager.markNotBusy(citizen);
             throw e;
         }
     }


### PR DESCRIPTION
## Description

Fixes #90 

When a citizen is playing a pregenerated greeting via `PregenerationPlayback.playAudioIfPossible()`, the citizen was not marked as busy in `ConversationManager`. This meant other handlers (urgent contact, mumbling) would see the citizen as available and start their own WebSocket audio session — producing two simultaneous voices for the same citizen.

## Root Cause

`PregenerationPlayback` used its own internal `ACTIVE_PREGENERATED_PLAYBACK` guard map to prevent duplicate *pregenerated* playback, but never called `ConversationManager.markBusy(citizen)`. The `isCitizenBusy()` check only looks at `clients`, `addedEntities`, `busyEntities`, and `backgroundSlots` — none of which were populated by the pregenerated playback path.

## Fix

- Call `ConversationManager.markBusy(citizen)` after the atomic `putIfAbsent` succeeds
- Call `ConversationManager.markNotBusy(citizen)` in every cleanup path: early returns (null channel, empty audio), the stream completion callback, and the exception handler

## Verification

- `isCitizenBusy()` now correctly returns `true` for a citizen playing pregenerated audio
- No other session type (urgent contact, mumbling, etc.) can start for the same citizen until playback completes