### PR TITLE
Add mixin smoke test dev tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,26 @@ When working with the Minecolonies API, look at the `scripts/MINECOLONIES_DOCS.m
 
 CI uses `./gradlew buildAndCollect --no-daemon`. JDK 25 (Microsoft) in CI.
 
+## Mixin Smoke Test
+
+After modifying any mixin class (in `src/main/java/me/sshcrack/mc_talking/mixin/`), you **must** verify it loads correctly on all supported versions. Run:
+
+```sh
+bash scripts/test-mixin-smoke.sh
+```
+
+This script:
+1. Discovers all version subprojects (1.21.1-neoforge, 1.20.1-forge) from `settings.gradle.kts`
+2. Launches each version's Minecraft client in parallel with `runClientAutoQuit`
+3. Each client auto-loads the first singleplayer world and quits after 60 ticks (~3s)
+4. Captures Gradle + Minecraft output to `/tmp/mixin-smoke-<version>-*.log`
+5. Copies each version's `run/logs/latest.log` alongside the Gradle output for deeper inspection
+6. Prints `[PASS]`/`[FAIL]` per version with the log file paths
+
+**What it tests:** The game starts, applies all mixins, enters a world, and shuts down cleanly without a crash. If a mixin has a bad target or causes a class-loading error, the game will fail to start or crash.
+
+**If a version fails:** Read the log file at the printed path and search for `mixin`, `error`, or `Exception`.
+
 ## Local Gemini Live Library
 
 For local development the Gemini Live Library can be included as a composite build at `../gemini-live-library`. When it exists, publishing tasks **fail** unless you confirm with:

--- a/build.forge.gradle.kts
+++ b/build.forge.gradle.kts
@@ -65,6 +65,25 @@ legacyForge {
             gameDirectory = file("run/")
             ideName = "Forge Server (${sc.current.version})"
         }
+
+        val autoQuitWorld = providers.gradleProperty("mc_talking.world").orElse("").get().let { name ->
+            if (name.isNotEmpty()) name
+            else file("run/saves").listFiles()
+                ?.filter { it.isDirectory }
+                ?.map { it.name }
+                ?.sorted()
+                ?.firstOrNull()
+                ?: error("No world found in run/saves/! Create a world first or use -Pmc_talking.world=<name>")
+        }
+
+        register("clientAutoQuit") {
+            client()
+            gameDirectory = file("run/")
+            ideName = "Forge Client AutoQuit (${sc.current.version})"
+            programArgument("--username=Dev")
+            programArgument("--quickPlaySingleplayer=$autoQuitWorld")
+            jvmArgument("-Dmc_talking.autoQuit=true")
+        }
     }
 
 

--- a/build.neoforge.gradle.kts
+++ b/build.neoforge.gradle.kts
@@ -65,6 +65,25 @@ neoForge {
             gameDirectory = file("run/")
             ideName = "NeoForge Server (${stonecutter.current.version})"
         }
+
+        val autoQuitWorld = providers.gradleProperty("mc_talking.world").orElse("").get().let { name ->
+            if (name.isNotEmpty()) name
+            else file("run/saves").listFiles()
+                ?.filter { it.isDirectory }
+                ?.map { it.name }
+                ?.sorted()
+                ?.firstOrNull()
+                ?: error("No world found in run/saves/! Create a world first or use -Pmc_talking.world=<name>")
+        }
+
+        register("clientAutoQuit") {
+            client()
+            gameDirectory = file("run/")
+            ideName = "NeoForge Client AutoQuit (${stonecutter.current.version})"
+            programArgument("--username=Dev")
+            programArgument("--quickPlaySingleplayer=$autoQuitWorld")
+            jvmArgument("-Dmc_talking.autoQuit=true")
+        }
     }
 
     mods {

--- a/scripts/test-mixin-smoke.sh
+++ b/scripts/test-mixin-smoke.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "=== Mixin Smoke Test ==="
+echo ""
+
+# Clean up stale temp files from previous runs
+rm -f /tmp/mixin-smoke-*.log
+
+# Discover all version-loader pairs from settings.gradle.kts
+VERSIONS=$(grep 'match("[0-9]' settings.gradle.kts | sed 's/.*match("\(.*\)", "\(.*\)").*/\1-\2/')
+if [ -z "$VERSIONS" ]; then
+    echo "ERROR: no versions found in settings.gradle.kts" >&2
+    exit 1
+fi
+
+echo "Versions under test:"
+for VERSION in $VERSIONS; do
+    echo "  - $VERSION"
+done
+echo ""
+
+# Run each version in parallel, capture output to temp files
+declare -a LOG_FILES
+declare -a PIDS
+declare -a VERSION_LIST
+
+I=0
+for VERSION in $VERSIONS; do
+    LOG_FILE=$(mktemp "/tmp/mixin-smoke-${VERSION}-XXXXXX.log")
+    LOG_FILES[$I]="$LOG_FILE"
+    VERSION_LIST[$I]="$VERSION"
+
+    (
+        echo "[$(date +%H:%M:%S)] === Starting mixin smoke test for $VERSION ==="
+        echo ""
+        cd "$ROOT_DIR"
+
+        if ./gradlew ":$VERSION:runClientAutoQuit" -Pmc_talking.devtools=true --no-daemon 2>&1; then
+            echo ""
+            echo "[$(date +%H:%M:%S)] === BUILD SUCCESSFUL: $VERSION ==="
+        else
+            echo ""
+            echo "[$(date +%H:%M:%S)] === BUILD FAILED: $VERSION ==="
+        fi
+    ) > "$LOG_FILE" 2>&1 &
+
+    PIDS[$I]=$!
+    echo "  Spawned: $VERSION (PID $!) -> $LOG_FILE"
+    I=$((I+1))
+done
+
+echo ""
+echo "Waiting for all builds to complete..."
+echo ""
+
+FAILED=0
+for I in "${!PIDS[@]}"; do
+    wait "${PIDS[$I]}" || FAILED=1
+done
+
+echo ""
+echo "=========================================="
+echo "=== Mixin Smoke Test Results            ==="
+echo "=========================================="
+echo ""
+
+for I in "${!VERSION_LIST[@]}"; do
+    VERSION="${VERSION_LIST[$I]}"
+    LOG_FILE="${LOG_FILES[$I]}"
+
+    # Determine status
+    if grep -q "BUILD SUCCESSFUL" "$LOG_FILE" 2>/dev/null; then
+        STATUS="PASS"
+    else
+        STATUS="FAIL"
+    fi
+
+    printf "  [%-4s] %-18s %s\n" "$STATUS" "$VERSION" "$LOG_FILE"
+done
+
+echo ""
+
+# Also copy latest Minecraft logs alongside the gradle output for easier debugging
+for I in "${!VERSION_LIST[@]}"; do
+    VERSION="${VERSION_LIST[$I]}"
+    LOG_FILE="${LOG_FILES[$I]}"
+    MC_LOG="versions/$VERSION/run/logs/latest.log"
+
+    if [ -f "$MC_LOG" ]; then
+        cp "$MC_LOG" "${LOG_FILE%.log}-minecraft.log"
+    fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "FAILED: one or more mixin smoke tests did not pass."
+    exit 1
+fi
+
+echo "All mixin smoke tests passed."

--- a/scripts/test-mixin-smoke.sh
+++ b/scripts/test-mixin-smoke.sh
@@ -23,6 +23,14 @@ for VERSION in $VERSIONS; do
 done
 echo ""
 
+cleanup() {
+    ./gradlew "Refresh active project" > /dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+./gradlew "Refresh active project" -Pmc_talking.devtools=true  > /dev/null 2>&1
+
 # Run each version in parallel, capture output to temp files
 declare -a LOG_FILES
 declare -a PIDS

--- a/src/main/java/me/sshcrack/mc_talking/McTalkingClient.java
+++ b/src/main/java/me/sshcrack/mc_talking/McTalkingClient.java
@@ -54,6 +54,9 @@ public class McTalkingClient {
     /*? if neoforge {*/
     public McTalkingClient(ModContainer container) {
         NeoForge.EVENT_BUS.register(this);
+        /*? if devtools {*/
+        me.sshcrack.mc_talking.devtools.DevAutoQuit.init();
+        /*?}*/
     }
     /*?}*/
 

--- a/src/main/java/me/sshcrack/mc_talking/devtools/DevAutoQuit.java
+++ b/src/main/java/me/sshcrack/mc_talking/devtools/DevAutoQuit.java
@@ -1,0 +1,65 @@
+/*? if devtools {*/
+package me.sshcrack.mc_talking.devtools;
+
+import net.minecraft.client.Minecraft;
+/*? if neoforge {*/
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
+import net.neoforged.neoforge.common.NeoForge;
+/*?}*/
+/*? if forge {*/
+/*import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.api.distmarker.Dist;
+*//*?}*/
+
+/*? if forge {*/
+/*@Mod.EventBusSubscriber(modid = "mc_talking", bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
+*//*?}*/
+public class DevAutoQuit {
+    private static boolean quitting = false;
+    private static int ticksSinceLoad = 0;
+    private static final int QUIT_DELAY_TICKS = 60;
+
+    /*? if neoforge {*/
+    public static void init() {
+        if (!isEnabled()) return;
+        NeoForge.EVENT_BUS.register(new DevAutoQuit());
+    }
+
+    @SubscribeEvent
+    public void onClientTick(ClientTickEvent.Post event) {
+        tick();
+    }
+    /*?}*/
+
+    /*? if forge {*/
+    /*@SubscribeEvent
+    public static void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) return;
+        tick();
+    }
+    *//*?}*/
+
+    private static boolean isEnabled() {
+        return "true".equals(System.getProperty("mc_talking.autoQuit"));
+    }
+
+    private static void tick() {
+        if (quitting || !isEnabled()) return;
+
+        var mc = Minecraft.getInstance();
+        if (mc.level == null || mc.player == null) {
+            ticksSinceLoad = 0;
+            return;
+        }
+
+        ticksSinceLoad++;
+        if (ticksSinceLoad >= QUIT_DELAY_TICKS) {
+            quitting = true;
+            mc.execute(mc::stop);
+        }
+    }
+}
+/*?}*/

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -47,6 +47,12 @@ tasks.register("runActiveServer") {
 	dependsOn(stonecutter.current!!.project + ":runServer")
 }
 
+tasks.register("runAutoQuitClient") {
+	group = "stonecutter"
+	description = "Run client, auto-load first singleplayer world, then quit (dev mixin testing)"
+	dependsOn(stonecutter.current!!.project + ":runClientAutoQuit")
+}
+
 stonecutter parameters {
 	constants.match(node.metadata.project.substringAfterLast('-'), "fabric", "neoforge", "forge")
 	filters.include("**/*.fsh", "**/*.vsh")
@@ -56,6 +62,7 @@ stonecutter parameters {
 	swaps["mod_group"] = "\"${sc.properties.get<String>("mod.group")}\";"
 	swaps["minecraft"] = "\"${node.metadata.version}\";"
 	constants["release"] = sc.properties.get<String>("mod.id") != "modtemplate"
+	constants["devtools"] = providers.gradleProperty("mc_talking.devtools").orElse("false").map { it.toBoolean() }.get()
 }
 
 subprojects {


### PR DESCRIPTION
Adds `runAutoQuitClient` Gradle task and `scripts/test-mixin-smoke.sh` for automated mixin verification.

- `runAutoQuitClient` launches Minecraft, auto-loads first singleplayer world, waits 60 ticks, then quits
- Compile-time gated behind Stonecutter `devtools` constant (`-Pmc_talking.devtools`)
- Runtime-gated behind `-Dmc_talking.autoQuit=true` system property
- `scripts/test-mixin-smoke.sh` runs all versions in parallel, captures logs to /tmp/
- AGENTS.md updated with Mixin Smoke Test section