### PR TITLE
fix: prevent AI from ending player conversations prematurely (#114)

### DIFF
--- a/src/main/java/me/sshcrack/mc_talking/manager/tools/EndConversationAction.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/tools/EndConversationAction.java
@@ -4,21 +4,29 @@ import com.google.gson.JsonObject;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import me.sshcrack.mc_talking.ConversationManager;
-import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class EndConversationAction extends GeneralFunctionAction {
     public EndConversationAction() {
         super("end_conversation", """
-                This will end the conversation. The peer you are talking to isn't able to respond after. Only use if you are sure you want to end the conversation.
+                Terminates the current autonomous conversation. The other party will not be able to respond.
+                WARNING: This CANNOT be used while a real player is speaking to you directly.
+                Only use this in autonomous contexts (mumbling, citizen-to-citizen conversations).
                 """);
     }
 
     @NotNull
     @Override
     public JsonObject execute(AbstractEntityCitizen citizen, IColony colony, @Nullable JsonObject parameters) {
+        var playerUUID = ConversationManager.getPlayerForEntity(citizen.getUUID());
+        if (playerUUID != null) {
+            var obj = new JsonObject();
+            obj.addProperty("success", false);
+            obj.addProperty("error", "You cannot end this conversation — a player is speaking to you. Continue talking to them.");
+            return obj;
+        }
+
         var client = ConversationManager.getClientForEntity(citizen.getUUID());
         var obj = new JsonObject();
 
@@ -30,19 +38,6 @@ public class EndConversationAction extends GeneralFunctionAction {
 
         client.endConversationWhenPossible();
         obj.addProperty("success", true);
-
-        var playerUUID = ConversationManager.getPlayerForEntity(citizen.getUUID());
-        if (playerUUID != null) {
-            var server = citizen.level().getServer();
-            if (server != null) {
-                var player = server.getPlayerList().getPlayer(playerUUID);
-                if (player != null) {
-                    player.sendSystemMessage(
-                            Component.translatable("mc_talking.colonist_ended_conversation")
-                                    .withStyle(ChatFormatting.YELLOW));
-                }
-            }
-        }
 
         return obj;
     }


### PR DESCRIPTION
Blocks the `end_conversation` AI tool during active player conversations by adding a runtime guard in `EndConversationAction.execute()`. When a player is present, the tool returns an error result to the model instead of ending the session. The tool description is also updated to make the restriction clear.

Closes #114