### PR TITLE
Scale housing complaint intensity by colony age

### DIFF
--- a/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
+++ b/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
@@ -225,6 +225,11 @@ public class McTalkingConfig {
     @SerialEntry(comment = "Minimum cooldown in seconds between urgent citizen contacts for the same player. Set to 0 to disable.")
     public int playerUrgentContactCooldownSeconds = 60;
 
+    @AutoGen(category = "citizens")
+    @TickBox
+    @SerialEntry(comment = "If true, housing complaint severity is scaled by colony age. Young colonies get patient/mild texts; older colonies get the full range of concern.")
+    public boolean scaleHousingComplaintsByAge = true;
+
     @AutoGen(category = "citizens", group = "citizen_contact")
     @DoubleSlider(min = 0.0, max = 1.0, step = 0.01)
     @SerialEntry(comment = "Base weight for casual greetings (0.0-1.0). Even content citizens get this small chance to wave/say hello per check interval. Multiplied by citizenContactBaseChance.")

--- a/src/main/java/me/sshcrack/mc_talking/manager/DefaultCitizenPromptProvider.java
+++ b/src/main/java/me/sshcrack/mc_talking/manager/DefaultCitizenPromptProvider.java
@@ -241,7 +241,13 @@ public class DefaultCitizenPromptProvider implements CitizenPromptProvider {
         }
 
         if (view.homeless()) {
-            prompt.append("- Very concerned about not having a home\n");
+            if (McTalkingConfig.INSTANCE.instance().scaleHousingComplaintsByAge && view.colonyAgeDays() < 7) {
+                prompt.append("- Not having a proper home yet is tough, but the colony is still getting set up\n");
+            } else if (McTalkingConfig.INSTANCE.instance().scaleHousingComplaintsByAge && view.colonyAgeDays() < 30) {
+                prompt.append("- Getting worried about not having a proper home — the colony should be more established by now\n");
+            } else {
+                prompt.append("- Very concerned about not having a home\n");
+            }
         }
 
         if (!view.child() && view.jobName() == null) {
@@ -470,17 +476,45 @@ public class DefaultCitizenPromptProvider implements CitizenPromptProvider {
                 case HOMELESSNESS:
                     if (factor < 0.8 && !view.guard()) {
                         if (factor < 0.3) {
-                            prompt.append("- ").append(MiscUtil.pick(
-                                "Sleeping without a proper roof over your head is wearing on you",
-                                "You desperately need a home — living like this is getting unbearable",
-                                "Not having a decent place to live is one of your biggest worries"
-                            )).append("\n");
+                            if (McTalkingConfig.INSTANCE.instance().scaleHousingComplaintsByAge && view.colonyAgeDays() < 7) {
+                                prompt.append("- ").append(MiscUtil.pick(
+                                    "Not having a proper home yet is tough, but the colony is still getting set up",
+                                    "You know the colony just started — you're willing to be patient about housing for now",
+                                    "Living without a proper roof is hard, but these things take time in a new colony"
+                                )).append("\n");
+                            } else if (McTalkingConfig.INSTANCE.instance().scaleHousingComplaintsByAge && view.colonyAgeDays() < 30) {
+                                prompt.append("- ").append(MiscUtil.pick(
+                                    "The lack of proper housing is starting to wear on you — the colony should be building homes by now",
+                                    "You've been without a real home for a while now and it's getting concerning",
+                                    "Not having proper shelter is becoming a real problem as the colony grows"
+                                )).append("\n");
+                            } else {
+                                prompt.append("- ").append(MiscUtil.pick(
+                                    "Sleeping without a proper roof over your head is wearing on you",
+                                    "You desperately need a home — living like this is getting unbearable",
+                                    "Not having a decent place to live is one of your biggest worries"
+                                )).append("\n");
+                            }
                         } else {
-                            prompt.append("- ").append(MiscUtil.pick(
-                                "Your current housing is cramped and basic — you wish for something better",
-                                "The shack you're living in barely counts as a proper home",
-                                "Your housing situation could be a lot better than this"
-                            )).append("\n");
+                            if (McTalkingConfig.INSTANCE.instance().scaleHousingComplaintsByAge && view.colonyAgeDays() < 7) {
+                                prompt.append("- ").append(MiscUtil.pick(
+                                    "Your housing is basic, but that's expected for a young colony",
+                                    "The cramped shelter is fine for now — the colony has only just started",
+                                    "Living in tight quarters is part of colony life in the early days"
+                                )).append("\n");
+                            } else if (McTalkingConfig.INSTANCE.instance().scaleHousingComplaintsByAge && view.colonyAgeDays() < 30) {
+                                prompt.append("- ").append(MiscUtil.pick(
+                                    "Your housing situation could use improvement as the colony matures",
+                                    "The basic shelter is getting old — you hope the colony expands housing soon",
+                                    "You're ready for better housing as the colony continues to develop"
+                                )).append("\n");
+                            } else {
+                                prompt.append("- ").append(MiscUtil.pick(
+                                    "Your current housing is cramped and basic — you wish for something better",
+                                    "The shack you're living in barely counts as a proper home",
+                                    "Your housing situation could be a lot better than this"
+                                )).append("\n");
+                            }
                         }
                     } else if (factor > 1.2) {
                         prompt.append("- ").append(MiscUtil.pick(

--- a/src/main/java/me/sshcrack/mc_talking/util/CitizenNeedAssessor.java
+++ b/src/main/java/me/sshcrack/mc_talking/util/CitizenNeedAssessor.java
@@ -45,7 +45,14 @@ public class CitizenNeedAssessor {
         }
 
         if (data.getHomeBuilding() == null && !CitizenHelper.isCitizenGuard(citizen)) {
-            weight += 0.7;
+            double homelessWeight = 0.7;
+            if (McTalkingConfig.INSTANCE.instance().scaleHousingComplaintsByAge) {
+                int colonyDay = data.getColony().getDay();
+                if (colonyDay < 7) {
+                    homelessWeight = 0.3;
+                }
+            }
+            weight += homelessWeight;
         }
 
         double saturation = data.getSaturation();

--- a/src/main/resources/assets/mc_talking/lang/en_us.json
+++ b/src/main/resources/assets/mc_talking/lang/en_us.json
@@ -184,6 +184,9 @@
   "yacl3.config.mc_talking:config.blockingTaskUrgencyMultiplier": "Blocking Task Urgency Multiplier",
   "yacl3.config.mc_talking:config.blockingTaskUrgencyMultiplier.desc": "Extra urgency weight for citizens stuck on a task (missing tools/items). Higher values make them much more likely to call for help.",
 
+  "yacl3.config.mc_talking:config.scaleHousingComplaintsByAge": "Scale Housing Complaints by Colony Age",
+  "yacl3.config.mc_talking:config.scaleHousingComplaintsByAge.desc": "If enabled, housing complaint severity and contact urgency are scaled by colony age. Early colonies get patient/mild text; mature colonies express full concern.",
+
   "yacl3.config.mc_talking:config.playerUrgentContactCooldownSeconds": "Player Urgent Contact Cooldown (seconds)",
   "yacl3.config.mc_talking:config.playerUrgentContactCooldownSeconds.desc": "Minimum time between urgent citizen contacts for the same player, preventing multiple citizens from calling out at once. Set to 0 to disable.",
 


### PR DESCRIPTION
## Summary

Colonists complained about housing with the same intensity regardless of colony age. A colonist moved into a freshly-built level 1 hut (the only shelter available) would accuse the player of providing a "cramped and basic" home — or, if homeless for even a few in-game days, would express "desperate" / "unbearable" language that doesn't fit a colony that's only a week old.

This is immersion-breaking because cramped basic shelters are expected at the start. The housing complaint text and citizen-initiated contact urgency treated homelessness/housing quality as **static**, with no awareness of colony age.

## Changes

### Config
- **McTalkingConfig**: Added `scaleHousingComplaintsByAge` boolean toggle (default `true`) so server admins can opt out.

### Prompt text (DefaultCitizenPromptProvider)
- **"Very concerned about not having a home" message** (line 243): Now age-aware — early colonists get patient text, established colony gets the original concern.
- **HOMELESSNESS modifier switch** (line 469): Three-tier scaling:
  - **Early colony (<7 days):** Patient, understanding text — "Not having a proper home yet is tough, but the colony is still getting set up"
  - **Transition (7-30 days):** Moderate concern — "The lack of proper housing is starting to wear on you"
  - **Established (>=30 days):** Original full-concern texts preserved unchanged

### Urgency weight (CitizenNeedAssessor)
- Homeless urgency weight reduced from `0.7` → `0.3` for colonies younger than 7 days, so new colonists are less likely to initiate contact specifically about housing.

### Localization
- Added `en_us.json` entries for the new config option.

Closes #117