### PR TITLE
feat: replace plain-text personality archetype list with dropdown preset picker

### DIFF
--- a/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
+++ b/src/main/java/me/sshcrack/mc_talking/config/McTalkingConfig.java
@@ -2,6 +2,7 @@ package me.sshcrack.mc_talking.config;
 
 import dev.isxander.yacl3.api.Option;
 import dev.isxander.yacl3.api.controller.ControllerBuilder;
+import dev.isxander.yacl3.api.controller.DropdownStringControllerBuilder;
 import dev.isxander.yacl3.api.controller.StringControllerBuilder;
 import dev.isxander.yacl3.config.v2.api.ConfigClassHandler;
 import dev.isxander.yacl3.config.v2.api.ConfigField;
@@ -371,8 +372,8 @@ public class McTalkingConfig {
     public boolean enablePersonalityArchetypes = true;
 
     @AutoGen(category = "citizens")
-    @ListGroup(valueFactory = ToolListFactory.class, controllerFactory = ToolListFactory.class)
-    @SerialEntry(comment = "Custom personality archetype strings added to the random pool citizens can be assigned. Each entry is a freeform instruction injected into the citizen's system prompt. Example: 'Always speak in rhyming couplets.'")
+    @ListGroup(valueFactory = PersonalityArchetypeListFactory.class, controllerFactory = PersonalityArchetypeListFactory.class)
+    @SerialEntry(comment = "Custom personality archetype strings added to the random pool citizens can be assigned. Each entry is a freeform instruction injected into the citizen's system prompt. Pick from presets or type your own.")
     public List<String> customPersonalityArchetypes = new ArrayList<>();
 
     // Colony Diplomacy
@@ -414,7 +415,43 @@ public class McTalkingConfig {
         }
     }
 
+    public static class PersonalityArchetypeListFactory implements ListGroup.ValueFactory<String>, ListGroup.ControllerFactory<String> {
+        private static final List<String> PRESETS = List.of(
+            "Optimist — upbeat and cheerful",
+            "Grump — cranky and blunt",
+            "Stoic — reserved and factual",
+            "Gossip — sociable and conspiratorial",
+            "Anxious — worrying and hesitant",
+            "Boastful — proud and competitive",
+            "Timid — soft-spoken and apologetic",
+            "Philosophical — reflective and thoughtful",
+            "Sarcastic — dry and witty",
+            "Dramatic — theatrical and exaggerated",
+            "Nurturing — caring and gentle",
+            "Competitive — achievement-driven",
+            "Curious — inquisitive and questioning",
+            "Nostalgic — sentimental and wistful",
+            "Superstitious — mystical and superstitious",
+            "Always speaks in rhyming couplets",
+            "Has a thick regional accent",
+            "Frequently quotes proverbs",
+            "Uses overly formal language",
+            "Speaks in metaphors and similes"
+        );
 
+        @Override
+        public String provideNewValue() {
+            return "";
+        }
+
+        @Override
+        public ControllerBuilder<String> createController(ListGroup annotation, ConfigField<List<String>> field, dev.isxander.yacl3.config.v2.api.autogen.OptionAccess storage, Option<String> option) {
+            return DropdownStringControllerBuilder.create(option)
+                .values(PRESETS)
+                .allowAnyValue(true)
+                .allowEmptyValue(false);
+        }
+    }
 
     public static boolean hasGeminiApiKey() {
         String key = INSTANCE.instance().geminiApiKey;

--- a/src/main/resources/assets/mc_talking/lang/en_us.json
+++ b/src/main/resources/assets/mc_talking/lang/en_us.json
@@ -198,7 +198,7 @@
   "yacl3.config.mc_talking:config.enablePersonalityArchetypes": "Enable Personality Archetypes",
   "yacl3.config.mc_talking:config.enablePersonalityArchetypes.desc": "If enabled, each citizen is randomly assigned a personality archetype (e.g. Optimist, Grump, Gossip) that persistently shapes how they speak.",
   "yacl3.config.mc_talking:config.customPersonalityArchetypes": "Custom Personality Archetypes",
-  "yacl3.config.mc_talking:config.customPersonalityArchetypes.desc": "Freeform personality descriptions added to the assignment pool. Each entry is a plain-English instruction injected into the citizen's system prompt. Example: 'Always speak in rhyming couplets.'",
+  "yacl3.config.mc_talking:config.customPersonalityArchetypes.desc": "Freeform personality descriptions added to the assignment pool. Each entry is a plain-English instruction injected into the citizen's system prompt. Click Add, then pick a preset from the dropdown or type your own. Example: 'Always speak in rhyming couplets.'",
 
   "yacl3.config.mc_talking:config.category.citizens.group.pregeneration": "Voice Pregeneration",
   "yacl3.config.mc_talking:config.enablePregeneration": "Enable Pregeneration",


### PR DESCRIPTION
## Summary

Replaces the plain-text-input list for `customPersonalityArchetypes` in the YACL config screen with an interactive dropdown that shows curated personality presets — instead of requiring manual text entry.

## Changes

- **McTalkingConfig.java**: Added `PersonalityArchetypeListFactory` inner class that implements `ListGroup.ValueFactory` and `ListGroup.ControllerFactory`
- The new factory uses `DropdownStringControllerBuilder` with 15 built-in derivative presets and 5 popular custom templates
- `allowAnyValue(true)` lets users still type custom entries not in the preset list
- Updated the `@ListGroup` annotation on `customPersonalityArchetypes` to reference the new factory
- **en_us.json**: Updated description to mention dropdown interaction

## Presets Included

- Built-in personality derivatives: Optimist, Grump, Stoic, Gossip, Anxious, Boastful, Timid, Philosophical, Sarcastic, Dramatic, Nurturing, Competitive, Curious, Nostalgic, Superstitious
- Popular custom templates: rhyming couplets, regional accent, proverbs, formal language, metaphors

Closes #128